### PR TITLE
refactor: extract daadi rules and variants

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "tsc -p tsconfig.test.json && echo '{\"type\":\"commonjs\"}' > dist/package.json && node --test dist/**/*.test.js"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -24,7 +24,6 @@
     "tailwindcss": "^3.4.9",
     "typescript": "^5.4.5",
     "vite": "^5.0.0",
-    "vite-plugin-node-polyfills": "^0.24.0",
-    "vitest": "^1.6.0"
+    "vite-plugin-node-polyfills": "^0.24.0"
   }
 }

--- a/apps/package.json
+++ b/apps/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -23,6 +24,7 @@
     "tailwindcss": "^3.4.9",
     "typescript": "^5.4.5",
     "vite": "^5.0.0",
-    "vite-plugin-node-polyfills": "^0.24.0"
+    "vite-plugin-node-polyfills": "^0.24.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/src/App.tsx
+++ b/apps/src/App.tsx
@@ -1,9 +1,9 @@
-import DaadiGame from './DaadiGame'
+import Gameplay from './daadi/Gameplay'
 
 export default function App() {
   return (
     <div className="min-h-screen">
-      <DaadiGame />
+      <Gameplay />
     </div>
   )
 }

--- a/apps/src/daadi/rules.test.ts
+++ b/apps/src/daadi/rules.test.ts
@@ -1,12 +1,27 @@
 import { describe, it, expect } from 'vitest';
 import { VARIANTS } from './variants';
-import { inMill, removables, destinationsFor, checkWin } from './rules';
+import {
+  inMill,
+  collectMill,
+  removables,
+  destinationsFor,
+  enterMoving,
+  winnerAfterRemoval,
+  checkWin,
+} from './rules';
 
 describe('rules helpers', () => {
   it('detects mills', () => {
     const b = Array(24).fill(0);
     b[0]=b[1]=b[2]=1;
     expect(inMill(b,1,1,VARIANTS.nine.mills)).toBe(true);
+  });
+
+  it('collects complete mills', () => {
+    const b = Array(24).fill(0);
+    b[0]=b[1]=b[2]=1;
+    const s = collectMill(b,1,VARIANTS.nine.mills);
+    expect([...s].sort()).toEqual([0,1,2]);
   });
 
   it('prefers removing pieces not in mills', () => {
@@ -17,6 +32,12 @@ describe('rules helpers', () => {
     const r = removables(b,1,VARIANTS.nine.mills);
     expect(r.has(3)).toBe(true);
     expect(r.has(0)).toBe(false);
+  });
+
+  it('enters moving phase only when all pieces placed and none to remove', () => {
+    expect(enterMoving({p1:0,p2:0}, null)).toBe(true);
+    expect(enterMoving({p1:1,p2:0}, null)).toBe(false);
+    expect(enterMoving({p1:0,p2:0}, 1)).toBe(false);
   });
 
   it('limits movement when not flying', () => {
@@ -31,6 +52,13 @@ describe('rules helpers', () => {
     const b = Array(24).fill(0);
     b[0]=b[14]=-1;
     expect(checkWin(b,1,'moving',VARIANTS.nine,'nine',true)).toBe(1);
+  });
+
+  it('detects immediate win after removal', () => {
+    const b = Array(24).fill(0);
+    b[0]=b[14]=-1;
+    expect(winnerAfterRemoval(b,1,'nine','moving')).toBe(1);
+    expect(winnerAfterRemoval(b,1,'nine','placing')).toBe(0);
   });
 
   it('detects no legal moves', () => {

--- a/apps/src/daadi/rules.test.ts
+++ b/apps/src/daadi/rules.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { VARIANTS } from './variants';
+import { inMill, removables, destinationsFor, checkWin } from './rules';
+
+describe('rules helpers', () => {
+  it('detects mills', () => {
+    const b = Array(24).fill(0);
+    b[0]=b[1]=b[2]=1;
+    expect(inMill(b,1,1,VARIANTS.nine.mills)).toBe(true);
+  });
+
+  it('prefers removing pieces not in mills', () => {
+    const b = Array(24).fill(0);
+    b[0]=b[1]=b[2]=-1;
+    b[3]=-1;
+    b[9]=1;
+    const r = removables(b,1,VARIANTS.nine.mills);
+    expect(r.has(3)).toBe(true);
+    expect(r.has(0)).toBe(false);
+  });
+
+  it('limits movement when not flying', () => {
+    const b = Array(24).fill(0);
+    b[22]=-1; b[0]=-1; b[2]=-1; b[14]=-1;
+    const dest = destinationsFor(b, VARIANTS.nine, 22, -1, 'nine', true);
+    const expected = VARIANTS.nine.adj[22].filter(n=>b[n]===0);
+    expect(dest.sort()).toEqual(expected.sort());
+  });
+
+  it('identifies win after reducing opponent to 2', () => {
+    const b = Array(24).fill(0);
+    b[0]=b[14]=-1;
+    expect(checkWin(b,1,'moving',VARIANTS.nine,'nine',true)).toBe(1);
+  });
+
+  it('detects no legal moves', () => {
+    const b = Array(9).fill(0);
+    b[0]=b[4]=b[8]=-1;
+    b[1]=b[3]=b[5]=b[7]=1;
+    expect(checkWin(b,-1,'moving',VARIANTS.three,'three',false)).toBe(1);
+  });
+});

--- a/apps/src/daadi/rules.test.ts
+++ b/apps/src/daadi/rules.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import { VARIANTS } from './variants';
 import {
   inMill,
@@ -14,14 +15,14 @@ describe('rules helpers', () => {
   it('detects mills', () => {
     const b = Array(24).fill(0);
     b[0]=b[1]=b[2]=1;
-    expect(inMill(b,1,1,VARIANTS.nine.mills)).toBe(true);
+    assert.strictEqual(inMill(b,1,1,VARIANTS.nine.mills), true);
   });
 
   it('collects complete mills', () => {
     const b = Array(24).fill(0);
     b[0]=b[1]=b[2]=1;
     const s = collectMill(b,1,VARIANTS.nine.mills);
-    expect([...s].sort()).toEqual([0,1,2]);
+    assert.deepStrictEqual([...s].sort(), [0,1,2]);
   });
 
   it('prefers removing pieces not in mills', () => {
@@ -30,14 +31,14 @@ describe('rules helpers', () => {
     b[3]=-1;
     b[9]=1;
     const r = removables(b,1,VARIANTS.nine.mills);
-    expect(r.has(3)).toBe(true);
-    expect(r.has(0)).toBe(false);
+    assert.strictEqual(r.has(3), true);
+    assert.strictEqual(r.has(0), false);
   });
 
   it('enters moving phase only when all pieces placed and none to remove', () => {
-    expect(enterMoving({p1:0,p2:0}, null)).toBe(true);
-    expect(enterMoving({p1:1,p2:0}, null)).toBe(false);
-    expect(enterMoving({p1:0,p2:0}, 1)).toBe(false);
+    assert.strictEqual(enterMoving({p1:0,p2:0}, null), true);
+    assert.strictEqual(enterMoving({p1:1,p2:0}, null), false);
+    assert.strictEqual(enterMoving({p1:0,p2:0}, 1), false);
   });
 
   it('limits movement when not flying', () => {
@@ -45,26 +46,26 @@ describe('rules helpers', () => {
     b[22]=-1; b[0]=-1; b[2]=-1; b[14]=-1;
     const dest = destinationsFor(b, VARIANTS.nine, 22, -1, 'nine', true);
     const expected = VARIANTS.nine.adj[22].filter(n=>b[n]===0);
-    expect(dest.sort()).toEqual(expected.sort());
+    assert.deepStrictEqual(dest.sort(), expected.sort());
   });
 
   it('identifies win after reducing opponent to 2', () => {
     const b = Array(24).fill(0);
     b[0]=b[14]=-1;
-    expect(checkWin(b,1,'moving',VARIANTS.nine,'nine',true)).toBe(1);
+    assert.strictEqual(checkWin(b,1,'moving',VARIANTS.nine,'nine',true), 1);
   });
 
   it('detects immediate win after removal', () => {
     const b = Array(24).fill(0);
     b[0]=b[14]=-1;
-    expect(winnerAfterRemoval(b,1,'nine','moving')).toBe(1);
-    expect(winnerAfterRemoval(b,1,'nine','placing')).toBe(0);
+    assert.strictEqual(winnerAfterRemoval(b,1,'nine','moving'), 1);
+    assert.strictEqual(winnerAfterRemoval(b,1,'nine','placing'), 0);
   });
 
   it('detects no legal moves', () => {
     const b = Array(9).fill(0);
     b[0]=b[4]=b[8]=-1;
     b[1]=b[3]=b[5]=b[7]=1;
-    expect(checkWin(b,-1,'moving',VARIANTS.three,'three',false)).toBe(1);
+    assert.strictEqual(checkWin(b,-1,'moving',VARIANTS.three,'three',false), 1);
   });
 });

--- a/apps/src/daadi/rules.ts
+++ b/apps/src/daadi/rules.ts
@@ -1,61 +1,134 @@
 import { K, P, Phase, Variant } from './variants';
 
-export const inMill = (b:number[], i:number, p:P, m:number[][]):boolean =>
-  m.some(x => x.includes(i) && x.every(j => b[j] === p));
+/**
+ * True if the piece at `idx` for `player` forms a mill.
+ */
+export function inMill(
+  board: number[],
+  idx: number,
+  player: P,
+  mills: number[][],
+): boolean {
+  return mills.some(
+    (mill) => mill.includes(idx) && mill.every((j) => board[j] === player),
+  );
+}
 
-export const collectMill = (b:number[], p:P, m:number[][]):Set<number> => {
-  const s = new Set<number>();
-  for (const x of m) if (x.every(i => b[i] === p)) x.forEach(i => s.add(i));
-  return s;
-};
-
-export const removables = (b:number[], rem:P, m:number[][]):Set<number> => {
-  const vic = rem === 1 ? -1 : 1;
-  const S = collectMill(b, vic as P, m);
-  const tot = b.filter(v => v === vic).length;
-  const R = new Set<number>();
-  b.forEach((v,i)=>{ if(v===vic) if(!S.has(i) || S.size===tot) R.add(i); });
-  return R;
-};
-
-export const canPlace = (tp:{p1:number;p2:number}, p:P):boolean => p===1?tp.p1>0:tp.p2>0;
-
-export const enterMoving = (tp:{p1:number;p2:number}, mr:P|null):boolean => tp.p1===0 && tp.p2===0 && mr===null;
-
-export const winnerAfterRemoval = (b:number[], rem:P, vk:K, ph:Phase):P|0 =>
-  (ph!== 'placing' && vk==='nine' && b.filter(v=>v=== (rem===1?-1:1)).length<=2 ? rem : 0) as P|0;
-
-export const destinationsFor = (
-  b:number[],
-  variant:Variant,
-  idx:number,
-  p:P,
-  vk:K,
-  flying:boolean
-):number[]=>{
-  const cnt=b.filter(v=>v===p).length;
-  const canFly=flying && vk==='nine' && cnt===3;
-  return canFly ? b.map((v,i)=>v===0?i:-1).filter(i=>i!==-1) : variant.adj[idx].filter(n=>b[n]===0);
-};
-
-export const checkWin = (
-  nb:number[],
-  toMove:P,
-  ph:Phase,
-  variant:Variant,
-  vk:K,
-  flying:boolean
-):P|0=>{
-  const my=toMove,
-        mc=nb.filter(v=>v===my).length,
-        oc=nb.filter(v=>v===-my as P).length;
-  if(ph!=='placing' && vk==='nine' && oc<=2) return my;
-  const canFly=flying && vk==='nine' && mc===3;
-  let has=false;
-  if(canFly) has=nb.some(v=>v===0);
-  else {
-    for(let i=0;i<nb.length;i++)
-      if(nb[i]===my && variant.adj[i].some(n=>nb[n]===0)) {has=true;break;}
+/**
+ * Collect all positions occupied by complete mills for `player`.
+ */
+export function collectMill(board: number[], player: P, mills: number[][]): Set<number> {
+  const result = new Set<number>();
+  for (const mill of mills) {
+    if (mill.every((i) => board[i] === player)) {
+      mill.forEach((i) => result.add(i));
+    }
   }
-  return ph!=='placing' && !has ? -my as P : 0;
+  return result;
+}
+
+/**
+ * Determine which opponent pieces may be removed when `remover` forms a mill.
+ * Prefer pieces not currently in a mill unless all are in mills.
+ */
+export function removables(board: number[], remover: P, mills: number[][]): Set<number> {
+  const victim = remover === 1 ? -1 : 1;
+  const victimMills = collectMill(board, victim as P, mills);
+  const totalVictims = board.filter((v) => v === victim).length;
+  const result = new Set<number>();
+
+  board.forEach((v, i) => {
+    if (v === victim && (!victimMills.has(i) || victimMills.size === totalVictims)) {
+      result.add(i);
+    }
+  });
+
+  return result;
+}
+
+/** Can the player still place a piece? */
+export const canPlace = (
+  toPlace: { p1: number; p2: number },
+  player: P,
+): boolean => (player === 1 ? toPlace.p1 > 0 : toPlace.p2 > 0);
+
+/** Enter moving phase once both players have placed all pieces and no removal pending. */
+export const enterMoving = (
+  toPlace: { p1: number; p2: number },
+  mustRemove: P | null,
+): boolean => toPlace.p1 === 0 && toPlace.p2 === 0 && mustRemove === null;
+
+/**
+ * Immediate win check after removing a piece.
+ * Only applies outside the placing phase in the nine-men variant.
+ */
+export const winnerAfterRemoval = (
+  board: number[],
+  remover: P,
+  variantKey: K,
+  phase: Phase,
+): P | 0 => {
+  if (phase !== 'placing' && variantKey === 'nine') {
+    const opponent = remover === 1 ? -1 : 1;
+    if (board.filter((v) => v === opponent).length <= 2) {
+      return remover;
+    }
+  }
+  return 0;
+};
+
+/**
+ * All legal destinations for `player` moving from `idx`.
+ */
+export const destinationsFor = (
+  board: number[],
+  variant: Variant,
+  idx: number,
+  player: P,
+  variantKey: K,
+  flying: boolean,
+): number[] => {
+  const count = board.filter((v) => v === player).length;
+  const canFly = flying && variantKey === 'nine' && count === 3;
+  if (canFly) {
+    return board.flatMap((v, i) => (v === 0 ? [i] : []));
+  }
+  return variant.adj[idx].filter((n) => board[n] === 0);
+};
+
+/**
+ * Determine the winner after `toMove` plays, or 0 if the game continues.
+ */
+export const checkWin = (
+  board: number[],
+  toMove: P,
+  phase: Phase,
+  variant: Variant,
+  variantKey: K,
+  flying: boolean,
+): P | 0 => {
+  const my = toMove;
+  const opponent = -my as P;
+  const myCount = board.filter((v) => v === my).length;
+  const oppCount = board.filter((v) => v === opponent).length;
+
+  if (phase !== 'placing' && variantKey === 'nine' && oppCount <= 2) {
+    return my;
+  }
+
+  const canFly = flying && variantKey === 'nine' && myCount === 3;
+  let hasMove = false;
+
+  if (canFly) {
+    hasMove = board.some((v) => v === 0);
+  } else {
+    for (let i = 0; i < board.length; i++) {
+      if (board[i] === my && variant.adj[i].some((n) => board[n] === 0)) {
+        hasMove = true;
+        break;
+      }
+    }
+  }
+
+  return phase !== 'placing' && !hasMove ? opponent : 0;
 };

--- a/apps/src/daadi/rules.ts
+++ b/apps/src/daadi/rules.ts
@@ -1,0 +1,61 @@
+import { K, P, Phase, Variant } from './variants';
+
+export const inMill = (b:number[], i:number, p:P, m:number[][]):boolean =>
+  m.some(x => x.includes(i) && x.every(j => b[j] === p));
+
+export const collectMill = (b:number[], p:P, m:number[][]):Set<number> => {
+  const s = new Set<number>();
+  for (const x of m) if (x.every(i => b[i] === p)) x.forEach(i => s.add(i));
+  return s;
+};
+
+export const removables = (b:number[], rem:P, m:number[][]):Set<number> => {
+  const vic = rem === 1 ? -1 : 1;
+  const S = collectMill(b, vic as P, m);
+  const tot = b.filter(v => v === vic).length;
+  const R = new Set<number>();
+  b.forEach((v,i)=>{ if(v===vic) if(!S.has(i) || S.size===tot) R.add(i); });
+  return R;
+};
+
+export const canPlace = (tp:{p1:number;p2:number}, p:P):boolean => p===1?tp.p1>0:tp.p2>0;
+
+export const enterMoving = (tp:{p1:number;p2:number}, mr:P|null):boolean => tp.p1===0 && tp.p2===0 && mr===null;
+
+export const winnerAfterRemoval = (b:number[], rem:P, vk:K, ph:Phase):P|0 =>
+  (ph!== 'placing' && vk==='nine' && b.filter(v=>v=== (rem===1?-1:1)).length<=2 ? rem : 0) as P|0;
+
+export const destinationsFor = (
+  b:number[],
+  variant:Variant,
+  idx:number,
+  p:P,
+  vk:K,
+  flying:boolean
+):number[]=>{
+  const cnt=b.filter(v=>v===p).length;
+  const canFly=flying && vk==='nine' && cnt===3;
+  return canFly ? b.map((v,i)=>v===0?i:-1).filter(i=>i!==-1) : variant.adj[idx].filter(n=>b[n]===0);
+};
+
+export const checkWin = (
+  nb:number[],
+  toMove:P,
+  ph:Phase,
+  variant:Variant,
+  vk:K,
+  flying:boolean
+):P|0=>{
+  const my=toMove,
+        mc=nb.filter(v=>v===my).length,
+        oc=nb.filter(v=>v===-my as P).length;
+  if(ph!=='placing' && vk==='nine' && oc<=2) return my;
+  const canFly=flying && vk==='nine' && mc===3;
+  let has=false;
+  if(canFly) has=nb.some(v=>v===0);
+  else {
+    for(let i=0;i<nb.length;i++)
+      if(nb[i]===my && variant.adj[i].some(n=>nb[n]===0)) {has=true;break;}
+  }
+  return ph!=='placing' && !has ? -my as P : 0;
+};

--- a/apps/src/daadi/variants.tsx
+++ b/apps/src/daadi/variants.tsx
@@ -1,0 +1,38 @@
+export type K = 'nine' | 'three';
+export type P = 1 | -1;
+export type Phase = 'placing' | 'moving' | 'removing';
+
+export type Variant = {
+  key: K;
+  points: [number, number][];
+  adj: number[][];
+  mills: number[][];
+  drawLines: (sx: number, o: number) => JSX.Element[];
+  initialPieces: number;
+  allowFlyingDefault: boolean;
+};
+
+const VNINE: Variant = {
+  key: 'nine',
+  points: [[0,0],[3,0],[6,0],[1,1],[3,1],[5,1],[2,2],[3,2],[4,2],[0,3],[1,3],[2,3],[4,3],[5,3],[6,3],[2,4],[3,4],[4,4],[1,5],[3,5],[5,5],[0,6],[3,6],[6,6]],
+  adj: [[1,9],[0,2,4],[1,14],[4,10],[1,3,5,7],[4,13],[7,11],[4,6,8,16],[7,12],[0,10,21],[3,9,11],[6,10,15],[8,13,17],[5,12,14],[2,13,23],[11,16],[7,15,17,19],[12,16],[19,10],[16,18,20,22],[19,13],[9,22],[19,21,23],[14,22]],
+  mills: [[0,1,2],[3,4,5],[6,7,8],[9,10,11],[12,13,14],[15,16,17],[18,19,20],[21,22,23],[0,9,21],[3,10,18],[6,11,15],[1,4,7],[16,19,22],[8,12,17],[5,13,20],[2,14,23]],
+  drawLines:(sx:number,o:number)=>{const L:JSX.Element[]=[];const ln=(a:number,b:number,c:number,d:number,k:string)=>(<line key={k} x1={o+a*sx} y1={o+b*sx} x2={o+c*sx} y2={o+d*sx} stroke="currentColor" strokeWidth={2}/>);[[0,0,6,0],[6,0,6,6],[6,6,0,6],[0,6,0,0]].forEach((v,i)=>L.push(ln(v[0],v[1],v[2],v[3],"o"+i)));[[1,1,5,1],[5,1,5,5],[5,5,1,5],[1,5,1,1]].forEach((v,i)=>L.push(ln(v[0],v[1],v[2],v[3],"m"+i)));[[2,2,4,2],[4,2,4,4],[4,4,2,4],[2,4,2,2]].forEach((v,i)=>L.push(ln(v[0],v[1],v[2],v[3],"i"+i)));[[3,0,3,2],[3,4,3,6],[0,3,2,3],[4,3,6,3]].forEach((v,i)=>L.push(ln(v[0],v[1],v[2],v[3],"c"+i)));return L;},
+  initialPieces:9,
+  allowFlyingDefault:true
+};
+
+const VTHREE: Variant = {
+  key: 'three',
+  points: [[0,0],[3,0],[6,0],[0,3],[3,3],[6,3],[0,6],[3,6],[6,6]],
+  adj: [[1,3],[0,2,4],[1,5],[0,4,6],[1,3,5,7],[2,4,8],[3,7],[4,6,8],[5,7]],
+  mills: [[0,1,2],[3,4,5],[6,7,8],[0,3,6],[1,4,7],[2,5,8]],
+  drawLines:(sx:number,o:number)=>{const L:JSX.Element[]=[];const ln=(a:number,b:number,c:number,d:number,k:string)=>(<line key={k} x1={o+a*sx} y1={o+b*sx} x2={o+c*sx} y2={o+d*sx} stroke="currentColor" strokeWidth={2}/>);[[0,0,6,0],[6,0,6,6],[6,6,0,6],[0,6,0,0],[0,3,6,3],[3,0,3,6]].forEach((v,i)=>L.push(ln(v[0],v[1],v[2],v[3],"t"+i)));return L;},
+  initialPieces:3,
+  allowFlyingDefault:false
+};
+
+export const VARIANTS: Record<K, Variant> = {
+  nine: VNINE,
+  three: VTHREE
+};

--- a/apps/src/daadi/variants.tsx
+++ b/apps/src/daadi/variants.tsx
@@ -4,35 +4,126 @@ export type Phase = 'placing' | 'moving' | 'removing';
 
 export type Variant = {
   key: K;
+  /** All board points in [x,y] coordinates */
   points: [number, number][];
+  /** Adjacency list describing legal moves */
   adj: number[][];
+  /** All possible mills (three in a row) */
   mills: number[][];
-  drawLines: (sx: number, o: number) => JSX.Element[];
+  /** Draw board lines with given scale and offset */
+  drawLines: (scale: number, offset: number) => JSX.Element[];
   initialPieces: number;
   allowFlyingDefault: boolean;
 };
 
+const drawSegments = (
+  segments: [number, number, number, number][],
+): ((scale: number, offset: number) => JSX.Element[]) => {
+  return (scale, offset) =>
+    segments.map(([a, b, c, d], i) => (
+      <line
+        key={i}
+        x1={offset + a * scale}
+        y1={offset + b * scale}
+        x2={offset + c * scale}
+        y2={offset + d * scale}
+        stroke="currentColor"
+        strokeWidth={2}
+      />
+    ));
+};
+
 const VNINE: Variant = {
   key: 'nine',
-  points: [[0,0],[3,0],[6,0],[1,1],[3,1],[5,1],[2,2],[3,2],[4,2],[0,3],[1,3],[2,3],[4,3],[5,3],[6,3],[2,4],[3,4],[4,4],[1,5],[3,5],[5,5],[0,6],[3,6],[6,6]],
-  adj: [[1,9],[0,2,4],[1,14],[4,10],[1,3,5,7],[4,13],[7,11],[4,6,8,16],[7,12],[0,10,21],[3,9,11],[6,10,15],[8,13,17],[5,12,14],[2,13,23],[11,16],[7,15,17,19],[12,16],[19,10],[16,18,20,22],[19,13],[9,22],[19,21,23],[14,22]],
-  mills: [[0,1,2],[3,4,5],[6,7,8],[9,10,11],[12,13,14],[15,16,17],[18,19,20],[21,22,23],[0,9,21],[3,10,18],[6,11,15],[1,4,7],[16,19,22],[8,12,17],[5,13,20],[2,14,23]],
-  drawLines:(sx:number,o:number)=>{const L:JSX.Element[]=[];const ln=(a:number,b:number,c:number,d:number,k:string)=>(<line key={k} x1={o+a*sx} y1={o+b*sx} x2={o+c*sx} y2={o+d*sx} stroke="currentColor" strokeWidth={2}/>);[[0,0,6,0],[6,0,6,6],[6,6,0,6],[0,6,0,0]].forEach((v,i)=>L.push(ln(v[0],v[1],v[2],v[3],"o"+i)));[[1,1,5,1],[5,1,5,5],[5,5,1,5],[1,5,1,1]].forEach((v,i)=>L.push(ln(v[0],v[1],v[2],v[3],"m"+i)));[[2,2,4,2],[4,2,4,4],[4,4,2,4],[2,4,2,2]].forEach((v,i)=>L.push(ln(v[0],v[1],v[2],v[3],"i"+i)));[[3,0,3,2],[3,4,3,6],[0,3,2,3],[4,3,6,3]].forEach((v,i)=>L.push(ln(v[0],v[1],v[2],v[3],"c"+i)));return L;},
-  initialPieces:9,
-  allowFlyingDefault:true
+  points: [
+    [0, 0], [3, 0], [6, 0],
+    [1, 1], [3, 1], [5, 1],
+    [2, 2], [3, 2], [4, 2],
+    [0, 3], [1, 3], [2, 3], [4, 3], [5, 3], [6, 3],
+    [2, 4], [3, 4], [4, 4],
+    [1, 5], [3, 5], [5, 5],
+    [0, 6], [3, 6], [6, 6],
+  ],
+  adj: [
+    [1, 9],           // 0
+    [0, 2, 4],        // 1
+    [1, 14],          // 2
+    [4, 10],          // 3
+    [1, 3, 5, 7],     // 4
+    [4, 13],          // 5
+    [7, 11],          // 6
+    [4, 6, 8, 16],    // 7
+    [7, 12],          // 8
+    [0, 10, 21],      // 9
+    [3, 9, 11],       // 10
+    [6, 10, 15],      // 11
+    [8, 13, 17],      // 12
+    [5, 12, 14],      // 13
+    [2, 13, 23],      // 14
+    [11, 16],         // 15
+    [7, 15, 17, 19],  // 16
+    [12, 16],         // 17
+    [19, 10],         // 18
+    [16, 18, 20, 22], // 19
+    [19, 13],         // 20
+    [9, 22],          // 21
+    [19, 21, 23],     // 22
+    [14, 22],         // 23
+  ],
+  mills: [
+    [0, 1, 2],   [3, 4, 5],   [6, 7, 8],
+    [9, 10, 11], [12, 13, 14], [15, 16, 17],
+    [18, 19, 20], [21, 22, 23],
+    [0, 9, 21],   [3, 10, 18], [6, 11, 15],
+    [1, 4, 7],    [16, 19, 22],
+    [8, 12, 17],  [5, 13, 20],
+    [2, 14, 23],
+  ],
+  drawLines: drawSegments([
+    // outer square
+    [0, 0, 6, 0], [6, 0, 6, 6], [6, 6, 0, 6], [0, 6, 0, 0],
+    // middle square
+    [1, 1, 5, 1], [5, 1, 5, 5], [5, 5, 1, 5], [1, 5, 1, 1],
+    // inner square
+    [2, 2, 4, 2], [4, 2, 4, 4], [4, 4, 2, 4], [2, 4, 2, 2],
+    // connections
+    [3, 0, 3, 2], [3, 4, 3, 6], [0, 3, 2, 3], [4, 3, 6, 3],
+  ]),
+  initialPieces: 9,
+  allowFlyingDefault: true,
 };
 
 const VTHREE: Variant = {
   key: 'three',
-  points: [[0,0],[3,0],[6,0],[0,3],[3,3],[6,3],[0,6],[3,6],[6,6]],
-  adj: [[1,3],[0,2,4],[1,5],[0,4,6],[1,3,5,7],[2,4,8],[3,7],[4,6,8],[5,7]],
-  mills: [[0,1,2],[3,4,5],[6,7,8],[0,3,6],[1,4,7],[2,5,8]],
-  drawLines:(sx:number,o:number)=>{const L:JSX.Element[]=[];const ln=(a:number,b:number,c:number,d:number,k:string)=>(<line key={k} x1={o+a*sx} y1={o+b*sx} x2={o+c*sx} y2={o+d*sx} stroke="currentColor" strokeWidth={2}/>);[[0,0,6,0],[6,0,6,6],[6,6,0,6],[0,6,0,0],[0,3,6,3],[3,0,3,6]].forEach((v,i)=>L.push(ln(v[0],v[1],v[2],v[3],"t"+i)));return L;},
-  initialPieces:3,
-  allowFlyingDefault:false
+  points: [
+    [0, 0], [3, 0], [6, 0],
+    [0, 3], [3, 3], [6, 3],
+    [0, 6], [3, 6], [6, 6],
+  ],
+  adj: [
+    [1, 3],        // 0
+    [0, 2, 4],     // 1
+    [1, 5],        // 2
+    [0, 4, 6],     // 3
+    [1, 3, 5, 7],  // 4
+    [2, 4, 8],     // 5
+    [3, 7],        // 6
+    [4, 6, 8],     // 7
+    [5, 7],        // 8
+  ],
+  mills: [
+    [0, 1, 2], [3, 4, 5], [6, 7, 8],
+    [0, 3, 6], [1, 4, 7], [2, 5, 8],
+  ],
+  drawLines: drawSegments([
+    [0, 0, 6, 0], [6, 0, 6, 6], [6, 6, 0, 6], [0, 6, 0, 0],
+    [0, 3, 6, 3], [3, 0, 3, 6],
+  ]),
+  initialPieces: 3,
+  allowFlyingDefault: false,
 };
 
 export const VARIANTS: Record<K, Variant> = {
   nine: VNINE,
-  three: VTHREE
+  three: VTHREE,
 };

--- a/apps/tsconfig.json
+++ b/apps/tsconfig.json
@@ -27,5 +27,8 @@
   },
   "include": [
     "src"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
   ]
 }

--- a/apps/tsconfig.test.json
+++ b/apps/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "module": "CommonJS",
+    "moduleResolution": "node"
+  },
+  "include": ["src"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary
- factor out board variants and drawing helpers
- centralize game logic helpers like mill detection and win checking
- move UI to `Gameplay` component and wire up new helpers
- add unit tests for rule utilities

## Testing
- `npm run build`
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b84d4b548324ba55ebbac88ff3ab