### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: apps/dist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Lazy SPA
 These single page apps are lazily created using AI and some sugar!
+
+## Deployment
+
+The `main` branch is automatically built and deployed to the `gh-pages` branch via GitHub Actions.

--- a/apps/vite.config.ts
+++ b/apps/vite.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { NodeGlobalsPolyfillPlugin } from '@esbuild-plugins/node-globals-polyfill'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), nodePolyfills({ globals: { Buffer: true }})]//NodeGlobalsPolyfillPlugin({ buffer: true})],
+  base: '/lazyspa/',
+  plugins: [react(), nodePolyfills({ globals: { Buffer: true } })],
 })


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy the SPA to gh-pages
- configure Vite base path for GitHub Pages
- document automatic deployment in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6b7cf7e8883249a54b267d24e7b02