### PR TITLE
fix gh-pages deployment lock file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: apps/package-lock.json
       - run: npm ci
       - run: npm run build
       - name: Deploy


### PR DESCRIPTION
## Summary
- point actions/setup-node cache to apps/package-lock.json

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6c28312148324a76db2fb9894ece3