### PR TITLE
feat: allow custom player names and colors

### DIFF
--- a/apps/src/App.tsx
+++ b/apps/src/App.tsx
@@ -2,7 +2,7 @@ import Gameplay from './daadi/Gameplay'
 
 export default function App() {
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen bg-gradient-to-br from-zinc-100 to-zinc-300 text-zinc-800 flex items-center justify-center py-4">
       <Gameplay />
     </div>
   )

--- a/apps/src/daadi/Gameplay.tsx
+++ b/apps/src/daadi/Gameplay.tsx
@@ -27,6 +27,10 @@ export default function Gameplay(){
   const [tests,setTests]=useState<ReturnType<typeof runTests>|null>(null); const [winner,setWinner]=useState<P|0>(0);
   const [dbg,setDbg]=useState(false); const [dbgActor,setDbgActor]=useState<P>(1);
   const [ply,setPly]=useState(1);
+  const [p1Name,setP1Name]=useState("Player 1");
+  const [p2Name,setP2Name]=useState("CPU");
+  const [p1Color,setP1Color]=useState("#0f0f0f");
+  const [p2Color,setP2Color]=useState("#ffffff");
   type Snap={board:number[];turn:P;phase:Phase;toPlace:{p1:number;p2:number};sel:number|null;mustRem:P|null;flying:boolean;last:{from:number|null;to:number|null}|null;msg:string;ply:number};
   const [hist,setHist]=useState<Snap[]>([]);const push=()=>setHist(h=>[...h,{board:[...board],turn,phase,toPlace:{...toPlace},sel,mustRem,flying,last: last?{...last}:null,msg,ply}]);
   const undo=()=>setHist(h=>{if(!h.length)return h;const s=h[h.length-1];setBoard(s.board);setTurn(s.turn);setPhase(s.phase);setTP(s.toPlace);setSel(s.sel);setMustRem(s.mustRem);setFlying(s.flying);setLast(s.last);setMsg(s.msg);setPly(s.ply);setWinner(0);return h.slice(0,-1)});
@@ -36,13 +40,15 @@ export default function Gameplay(){
   const stateStr=useMemo(()=>JSON.stringify({variant:vk,board,turn,phase,toPlace,mustRem,flying},null,2),[vk,board,turn,phase,toPlace,mustRem,flying]);
   const legal=(i:number,p:P)=>{ if(board[i]!==p||phase!=='moving'||mustRem!==null||winner!==0) return []; return destinationsFor(board,V,i,p,vk,flying); };
   const moveMsg=()=>`All pieces placed. Move along lines${vk==='nine'&&flying?' (or fly at 3)':''}.`;
+  const nameOf=(p:P)=>p===1?p1Name:p2Name;
+  const colorOf=(p:P)=>p===1?p1Color:p2Color;
 
   const click=(idx:number)=>{
     if((cpu&&turn===-1)||winner!==0)return;
     if(dbg&&phase==='placing'&&mustRem===null){push();const nb=board.slice();nb[idx]=nb[idx]===0?dbgActor:0;setBoard(nb);setMsg(`Debug: ${nb[idx]===0?'cleared':(nb[idx]===1?'P1':'P2')} at ${idx}.`);return}
-    if(mustRem!==null){const rem=mustRem; if(board[idx]!== (rem===1?-1:1))return; const R=[...removables(board,rem,V.mills)]; if(!R.includes(idx))return; push(); const nb=board.slice(); nb[idx]=0; setBoard(nb); setMustRem(null); const immediate=winnerAfterRemoval(nb,rem,vk,phase); if(immediate){setWinner(immediate);setMsg(`${immediate===1?'Player 1':(cpu?'CPU':'Player 2')} wins!`);setPhase('removing');return;} const ntp=nt(turn); setTurn(ntp); setPly(p=>p+1); if(phase==='placing'){ if(enterMoving(toPlace,null)){setPhase('moving');setMsg(moveMsg())} else setMsg(ntp===1?"Player 1: place":"Player 2: place"); } else { setMsg(ntp===1?"Player 1 to move.":"Player 2 to move."); } const w=checkWin(nb,ntp,phase,V,vk,flying); if(w){setMsg(`${w===1?'Player 1':(cpu?'CPU':'Player 2')} wins!`);setPhase('removing');setWinner(w);} return }
-    if(phase==='placing'){ if(!canPlace(toPlace,turn)||board[idx]!==0)return; push(); const nb=board.slice(); nb[idx]=turn; setBoard(nb); const nextTP=turn===1?{p1:toPlace.p1-1,p2:toPlace.p2}:{p1:toPlace.p1,p2:toPlace.p2-1}; setTP(nextTP); if(inMill(nb,idx,turn as P,V.mills)){setMustRem(turn);setMsg(`${turn===1?'Player 1':'Player 2'} formed a mill! Remove one.`)} else { const ntp=nt(turn); setTurn(ntp); setPly(p=>p+1); if(enterMoving(nextTP,null)){setPhase('moving');setMsg(moveMsg())} else setMsg(ntp===1?"Player 1: place":"Player 2: place"); } return }
-    if(phase==='moving'){ if(sel===null){ if(board[idx]!==turn)return; if(!legal(idx,turn).length)return; setSel(idx); setMsg('Select a target.'); } else { if(board[idx]===turn){ if(!legal(idx,turn).length)return; setSel(idx); return } const L=legal(sel,turn); if(!L.includes(idx))return; push(); const nb=board.slice(); nb[sel]=0; nb[idx]=turn; setBoard(nb); setLast({from:sel,to:idx}); setSel(null); if(inMill(nb,idx,turn,V.mills)){setMustRem(turn);setMsg(`${turn===1?'Player 1':'Player 2'} formed a mill! Remove one.`);return} const ntp=nt(turn); setTurn(ntp); setPly(p=>p+1); setMsg(ntp===1?"Player 1 to move.":"Player 2 to move."); const w=checkWin(nb,ntp,'moving',V,vk,flying); if(w){setMsg(`${w===1?'Player 1':(cpu?'CPU':'Player 2')} wins!`);setPhase('removing');setWinner(w);} }}
+    if(mustRem!==null){const rem=mustRem; if(board[idx]!== (rem===1?-1:1))return; const R=[...removables(board,rem,V.mills)]; if(!R.includes(idx))return; push(); const nb=board.slice(); nb[idx]=0; setBoard(nb); setMustRem(null); const immediate=winnerAfterRemoval(nb,rem,vk,phase); if(immediate){setWinner(immediate);setMsg(`${nameOf(immediate as P)} wins!`);setPhase('removing');return;} const ntp=nt(turn); setTurn(ntp); setPly(p=>p+1); if(phase==='placing'){ if(enterMoving(toPlace,null)){setPhase('moving');setMsg(moveMsg())} else setMsg(`${nameOf(ntp)}: place`); } else { setMsg(`${nameOf(ntp)} to move.`); } const w=checkWin(nb,ntp,phase,V,vk,flying); if(w){setMsg(`${nameOf(w as P)} wins!`);setPhase('removing');setWinner(w);} return }
+    if(phase==='placing'){ if(!canPlace(toPlace,turn)||board[idx]!==0)return; push(); const nb=board.slice(); nb[idx]=turn; setBoard(nb); const nextTP=turn===1?{p1:toPlace.p1-1,p2:toPlace.p2}:{p1:toPlace.p1,p2:toPlace.p2-1}; setTP(nextTP); if(inMill(nb,idx,turn as P,V.mills)){setMustRem(turn);setMsg(`${nameOf(turn)} formed a mill! Remove one.`)} else { const ntp=nt(turn); setTurn(ntp); setPly(p=>p+1); if(enterMoving(nextTP,null)){setPhase('moving');setMsg(moveMsg())} else setMsg(`${nameOf(ntp)}: place`); } return }
+    if(phase==='moving'){ if(sel===null){ if(board[idx]!==turn)return; if(!legal(idx,turn).length)return; setSel(idx); setMsg('Select a target.'); } else { if(board[idx]===turn){ if(!legal(idx,turn).length)return; setSel(idx); return } const L=legal(sel,turn); if(!L.includes(idx))return; push(); const nb=board.slice(); nb[sel]=0; nb[idx]=turn; setBoard(nb); setLast({from:sel,to:idx}); setSel(null); if(inMill(nb,idx,turn,V.mills)){setMustRem(turn);setMsg(`${nameOf(turn)} formed a mill! Remove one.`);return} const ntp=nt(turn); setTurn(ntp); setPly(p=>p+1); setMsg(`${nameOf(ntp)} to move.`); const w=checkWin(nb,ntp,'moving',V,vk,flying); if(w){setMsg(`${nameOf(w as P)} wins!`);setPhase('removing');setWinner(w);} }}
   };
 
   // CPU
@@ -84,9 +90,9 @@ export default function Gameplay(){
     for(let d=1; d<=Dmax; d++){ negamax(board,phase,toPlace,p,d,-1e9,1e9); if(Date.now()-start>budget) break; }
     return rootBest;
   };
-  const doCPU=(a:Act)=>{ if(winner!==0)return; if(a.type==='remove'){push();const nb=board.slice();nb[a.idx]=0;setBoard(nb);setMustRem(null);const imm=winnerAfterRemoval(nb,-1,vk,phase);if(imm){setWinner(imm);setMsg('CPU wins!');setPhase('removing');return;} const ntp=nt(turn);setTurn(ntp); setPly(p=>p+1); if(phase==='placing'){ if(enterMoving(toPlace,null)){setPhase('moving');setMsg(moveMsg())} else setMsg(ntp===1?'Player 1: place':'Player 2: place'); } else { setMsg('Player 1 to move.'); } const w=checkWin(nb,ntp,phase,V,vk,flying); if(w){setMsg(`${w===1?'Player 1':'CPU'} wins!`);setPhase('removing');setWinner(w);} return }
-    if(phase==='placing'&&a.type==='place'){push();const nb=board.slice();nb[a.to]=-1;setBoard(nb);const tp={p1:toPlace.p1,p2:toPlace.p2-1};setTP(tp); if(inMill(nb,a.to,-1,VARIANTS[vk].mills)){setMustRem(-1);setMsg('CPU formed a mill! Removing...');} else {const ntp=nt(-1);setTurn(ntp); if(enterMoving(tp,null)){setPhase('moving');setMsg(moveMsg())} else setMsg('Player 1: place');} return }
-    if(phase==='moving'&&a.type==='move'){push();const allowed=destinationsFor(board,VARIANTS[vk],a.from,-1 as P,vk,flying); if(!allowed.includes(a.to)) { return; } const nb=board.slice();nb[a.from]=0;nb[a.to]=-1;setBoard(nb);setLast({from:a.from,to:a.to}); if(inMill(nb,a.to,-1,VARIANTS[vk].mills)){setMustRem(-1);setMsg('CPU formed a mill! Removing...');} else {const ntp=nt(-1);setTurn(ntp);setMsg('Player 1 to move.');const w=checkWin(nb,ntp,'moving',V,vk,flying); if(w){setMsg(`${w===1?'Player 1':'CPU'} wins!`);setPhase('removing');setWinner(w);}} } };
+  const doCPU=(a:Act)=>{ if(winner!==0)return; if(a.type==='remove'){push();const nb=board.slice();nb[a.idx]=0;setBoard(nb);setMustRem(null);const imm=winnerAfterRemoval(nb,-1,vk,phase);if(imm){setWinner(imm);setMsg(`${nameOf(-1)} wins!`);setPhase('removing');return;} const ntp=nt(turn);setTurn(ntp); setPly(p=>p+1); if(phase==='placing'){ if(enterMoving(toPlace,null)){setPhase('moving');setMsg(moveMsg())} else setMsg(`${nameOf(ntp)}: place`); } else { setMsg(`${nameOf(1)} to move.`); } const w=checkWin(nb,ntp,phase,V,vk,flying); if(w){setMsg(`${nameOf(w as P)} wins!`);setPhase('removing');setWinner(w);} return }
+    if(phase==='placing'&&a.type==='place'){push();const nb=board.slice();nb[a.to]=-1;setBoard(nb);const tp={p1:toPlace.p1,p2:toPlace.p2-1};setTP(tp); if(inMill(nb,a.to,-1,VARIANTS[vk].mills)){setMustRem(-1);setMsg(`${nameOf(-1)} formed a mill! Removing...`);} else {const ntp=nt(-1);setTurn(ntp); if(enterMoving(tp,null)){setPhase('moving');setMsg(moveMsg())} else setMsg(`${nameOf(1)}: place`);} return }
+    if(phase==='moving'&&a.type==='move'){push();const allowed=destinationsFor(board,VARIANTS[vk],a.from,-1 as P,vk,flying); if(!allowed.includes(a.to)) { return; } const nb=board.slice();nb[a.from]=0;nb[a.to]=-1;setBoard(nb);setLast({from:a.from,to:a.to}); if(inMill(nb,a.to,-1,VARIANTS[vk].mills)){setMustRem(-1);setMsg(`${nameOf(-1)} formed a mill! Removing...`);} else {const ntp=nt(-1);setTurn(ntp);setMsg(`${nameOf(1)} to move.`);const w=checkWin(nb,ntp,'moving',V,vk,flying); if(w){setMsg(`${nameOf(w as P)} wins!`);setPhase('removing');setWinner(w);}} } };
   useEffect(()=>{ if(!cpu||winner!==0||(dbg&&phase!=='moving')||turn!==-1||((mustRem!==null&&mustRem!==-1))||thinking.current)return; thinking.current=true; const t=setTimeout(()=>{const pick=searchBest(-1 as P); if(pick){ if(pick.remove!==undefined){ doCPU({type:'remove', idx: pick.remove}); } else { doCPU(pick.act); } } thinking.current=false},320); return()=>{clearTimeout(t);thinking.current=false} },[cpu,turn,phase,board,mustRem,flying,vk,toPlace,winner,dbg]);
 
   const sx=80, off=20, toXY=(p:[number,number])=>({cx:off+p[0]*sx,cy:off+p[1]*sx});
@@ -94,7 +100,7 @@ export default function Gameplay(){
   const remSet=useMemo(()=>mustRem===null?new Set<number>():removables(board,mustRem,VARIANTS[vk].mills),[board,mustRem,vk]);
   const Title= vk==='nine'? 'Daadi • Navakankari' : 'Chinna Daadi';
 
-  return (<div className="min-h-screen w-full bg-zinc-50 text-zinc-900 flex flex-col items-center py-6">
+  return (<div className="min-h-screen w-full bg-white/70 backdrop-blur flex flex-col items-center py-6 text-zinc-900">
     <div className="w-full max-w-6xl px-2 sm:px-4 mb-4">
       <div className="flex items-center justify-between">
         <a href="/" className="text-sm px-3 py-1.5 rounded-lg bg-white border border-zinc-300 hover:bg-zinc-100">🏠 Home</a>
@@ -113,7 +119,7 @@ export default function Gameplay(){
           {VARIANTS[vk].points.map((p,i)=>{const {cx,cy}=toXY(p);const o=board[i];const seld=sel===i;const lastHit=last&&(last.from===i||last.to===i);const canGo=sel!==null&&legal(sel,turn).includes(i);const canPlaceHere=phase==='placing'&&board[i]===0&&mustRem===null&&(turn===1||!cpu)&&canPlace(toPlace,turn)&&!dbg;const canRem=mustRem!==null&&remSet.has(i)&&board[i]===(mustRem===1?-1:1);const inM=o===1?mill1.has(i):o===-1?mill2.has(i):false;return (
             <g key={i} onClick={()=>click(i)} className={cpu&&turn===-1?"cursor-not-allowed":"cursor-pointer"}>
               {board[i]===0&&(canGo||canPlaceHere)&&<circle cx={cx} cy={cy} r={18} className="fill-emerald-200/50"/>}
-              {o!==0&&<circle cx={cx} cy={cy} r={18} className={`${o===1?"fill-zinc-900":"fill-white"} stroke-zinc-900 stroke-[1.5px]${seld?" ring-4 ring-blue-300":""}${canRem?" ring-4 ring-rose-300":""}`}/>} 
+              {o!==0&&<circle cx={cx} cy={cy} r={18} className={`stroke-zinc-900 stroke-[1.5px]${seld?" ring-4 ring-blue-300":""}${canRem?" ring-4 ring-rose-300":""}`} style={{fill:colorOf(o as P)}}/>}
               {o===0&&<circle cx={cx} cy={cy} r={7} className="fill-zinc-700"/>}
               {inM&&<circle cx={cx} cy={cy} r={4} className="fill-amber-400"/>}
               {lastHit&&<circle cx={cx} cy={cy} r={22} className="fill-transparent stroke-blue-400 stroke-2"/>}
@@ -126,18 +132,32 @@ export default function Gameplay(){
           <div className="flex items-center justify-between gap-2 flex-wrap"><span className="text-lg font-semibold">Status</span><div className="flex items-center gap-2"><button onClick={undo} className="text-sm px-3 py-1.5 rounded-lg bg-white border border-zinc-300 hover:bg-zinc-100">Undo</button><button onClick={()=>reset(true)} className="text-sm px-3 py-1.5 rounded-lg bg-zinc-900 text-white hover:bg-zinc-800">Reset</button></div></div>
           <div className="mt-3 text-sm leading-relaxed">
             <div className="mb-2"><span className="px-2 py-1 rounded bg-zinc-100 mr-2">Phase</span><span className="font-medium capitalize">{phase==='placing'?"Placing":phase==='moving'?"Moving":mustRem!==null?"Removing":"Game Over"}</span></div>
-            <div className="mb-2 flex items-center gap-2"><span className="px-2 py-1 rounded bg-zinc-100">Turn</span><span className={`font-semibold ${turn===1?"text-zinc-900":"text-zinc-600"}`}>{turn===1?"Player 1":"CPU"}</span></div>
+            <div className="mb-2 flex items-center gap-2"><span className="px-2 py-1 rounded bg-zinc-100">Turn</span><span className={`font-semibold ${turn===1?"text-zinc-900":"text-zinc-600"}`}>{nameOf(turn)}</span></div>
             <div className="mb-2"><span className="px-2 py-1 rounded bg-zinc-100 mr-2">Move</span><span className="font-medium">{ply}</span></div>
             <p className="text-zinc-700">{msg}</p>
           </div>
-          <div className="mt-3 flex flex-col gap-2 text-sm text-zinc-600"><div>● Player 1 on board: {counts.p1} &nbsp; to place: {toPlace.p1}</div><div>○ CPU (P2) on board: {counts.p2} &nbsp; to place: {toPlace.p2}</div></div>
+          <div className="mt-3 flex flex-col gap-2 text-sm text-zinc-600">
+            <div className="flex items-center gap-2"><span className="w-3 h-3 rounded-full border" style={{background:p1Color}}></span>{p1Name} on board: {counts.p1} &nbsp; to place: {toPlace.p1}</div>
+            <div className="flex items-center gap-2"><span className="w-3 h-3 rounded-full border" style={{background:p2Color}}></span>{p2Name} on board: {counts.p2} &nbsp; to place: {toPlace.p2}</div>
+          </div>
         </div>
 
         <div className="bg-white rounded-2xl shadow p-4">
           <div className="flex items-center justify-between gap-2"><span className="text-lg font-semibold">Options</span>{dbg && (<button onClick={()=>setTests(runTests())} className="text-xs px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100">Run tests</button>)}</div>
           <div className="mt-3 text-sm space-y-3">
-            <label className="flex items-center gap-2 select-none"><input type="checkbox" checked={cpu} onChange={e=>setCPU(e.target.checked)}/><span>CPU as Player 2</span></label>
+            <label className="flex items-center gap-2 select-none"><input type="checkbox" checked={cpu} onChange={e=>{setCPU(e.target.checked); if(e.target.checked) setP2Name('CPU'); else if(p2Name==='CPU') setP2Name('Player 2');}}/><span>CPU as Player 2</span></label>
             {vk==='nine'&&<label className="flex items-center gap-2 select-none"><input type="checkbox" checked={flying} onChange={e=>setFlying(e.target.checked)}/><span>Allow flying at 3</span></label>}
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <input type="color" value={p1Color} onChange={e=>setP1Color(e.target.value)} className="h-8 w-8 p-0 border rounded"/>
+                <input type="text" value={p1Name} onChange={e=>setP1Name(e.target.value)} className="flex-1 border rounded px-2 py-1"/>
+              </div>
+              <div className="flex items-center gap-2">
+                <input type="color" value={p2Color} onChange={e=>setP2Color(e.target.value)} className="h-8 w-8 p-0 border rounded"/>
+                <input type="text" value={p2Name} onChange={e=>setP2Name(e.target.value)} disabled={cpu} className="flex-1 border rounded px-2 py-1 disabled:opacity-50"/>
+              </div>
+              <button onClick={()=>{setP1Color(p2Color);setP2Color(p1Color);}} className="text-xs px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100">Swap colors</button>
+            </div>
             {dbg && (<label className="flex items-center gap-2 select-none"><input type="checkbox" checked={dbg} onChange={e=>setDbg(e.target.checked)}/><span>Test / Debug mode</span></label>)}
             {dbg&&<div className="ml-5 space-y-2">
               <div className="flex items-center gap-3"><span className="text-zinc-600">Place as:</span><label className="flex items-center gap-1"><input type="radio" name="dbgActor" checked={dbgActor===1} onChange={()=>setDbgActor(1)}/><span>Player 1</span></label><label className="flex items-center gap-1"><input type="radio" name="dbgActor" checked={dbgActor===-1} onChange={()=>setDbgActor(-1)}/><span>Player 2</span></label></div>
@@ -177,8 +197,8 @@ export default function Gameplay(){
 
     {winner!==0&&(<div className="fixed inset-0 bg-black/30 flex items-center justify-center p-4 z-50"><div className="bg-white rounded-2xl shadow-xl p-6 w-full max-w-sm text-center relative overflow-hidden">
       <style>{`@keyframes blink{0%,80%,100%{opacity:.25}40%{opacity:1}}@keyframes dash{from{stroke-dashoffset:140}to{stroke-dashoffset:0}}`}</style>
-      <div className="flex items-center justify-center mb-3"><svg width="180" height="40" viewBox="0 0 180 40">{(()=>{const isP1=winner===1,d=isP1?"#0f0f0f":"#ffffff",common:any={r:6};return(<g><circle cx="20" cy="20" {...common} fill={d} stroke="#0f0f0f" style={{animation:"blink 1.2s infinite" as any}}/><circle cx="90" cy="20" {...common} fill={d} stroke="#0f0f0f" style={{animation:"blink 1.2s .2s infinite" as any}}/><circle cx="160" cy="20" {...common} fill={d} stroke="#0f0f0f" style={{animation:"blink 1.2s .4s infinite" as any}}/><line x1="26" y1="20" x2="84" y2="20" stroke={d} strokeWidth="3" strokeDasharray="140" strokeDashoffset="140" style={{animation:"dash 1.2s ease forwards" as any}}/><line x1="96" y1="20" x2="154" y2="20" stroke={d} strokeWidth="3" strokeDasharray="140" strokeDashoffset="140" style={{animation:"dash 1.2s .2s ease forwards" as any}}/></g>)})()}</svg></div>
-      <div className="text-2xl font-semibold mb-1">🏆 {winner===1?"Player 1":"CPU"} wins!</div>
+      <div className="flex items-center justify-center mb-3"><svg width="180" height="40" viewBox="0 0 180 40">{(()=>{const isP1=winner===1;const d=colorOf(isP1?1:-1);const common:any={r:6};return(<g><circle cx="20" cy="20" {...common} fill={d} stroke="#0f0f0f" style={{animation:"blink 1.2s infinite" as any}}/><circle cx="90" cy="20" {...common} fill={d} stroke="#0f0f0f" style={{animation:"blink 1.2s .2s infinite" as any}}/><circle cx="160" cy="20" {...common} fill={d} stroke="#0f0f0f" style={{animation:"blink 1.2s .4s infinite" as any}}/><line x1="26" y1="20" x2="84" y2="20" stroke={d} strokeWidth="3" strokeDasharray="140" strokeDashoffset="140" style={{animation:"dash 1.2s ease forwards" as any}}/><line x1="96" y1="20" x2="154" y2="20" stroke={d} strokeWidth="3" strokeDasharray="140" strokeDashoffset="140" style={{animation:"dash 1.2s .2s ease forwards" as any}}/></g>)})()}</svg></div>
+      <div className="text-2xl font-semibold mb-1">🏆 {nameOf(winner as P)} wins!</div>
       <p className="text-sm text-zinc-600 mb-4">Good game.</p>
       <button onClick={()=>reset(true)} className="px-4 py-2 rounded-lg bg-zinc-900 text-white hover:bg-zinc-800">New game</button>
     </div></div>)}


### PR DESCRIPTION
## Summary
- add player name and color customization with color swapping
- modernize UI layout with gradient backdrop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6c43eeb188324bc551b45d188471e