### PR TITLE
Fix win detection bugs and expand test coverage

### DIFF
--- a/apps/src/daadi/rules.test.ts
+++ b/apps/src/daadi/rules.test.ts
@@ -52,7 +52,14 @@ describe('rules helpers', () => {
   it('identifies win after reducing opponent to 2', () => {
     const b = Array(24).fill(0);
     b[0]=b[14]=-1;
-    assert.strictEqual(checkWin(b,1,'moving',VARIANTS.nine,'nine',true), 1);
+    assert.strictEqual(checkWin(b,-1,'moving',VARIANTS.nine,'nine',true), 1);
+  });
+
+  it('flags loss for player with only two pieces', () => {
+    const b = Array(24).fill(0);
+    b[0]=b[14]=1;
+    b[3]=b[4]=b[5]=-1;
+    assert.strictEqual(checkWin(b,1,'moving',VARIANTS.nine,'nine',true), -1);
   });
 
   it('detects immediate win after removal', () => {
@@ -60,6 +67,12 @@ describe('rules helpers', () => {
     b[0]=b[14]=-1;
     assert.strictEqual(winnerAfterRemoval(b,1,'nine','moving'), 1);
     assert.strictEqual(winnerAfterRemoval(b,1,'nine','placing'), 0);
+  });
+
+  it('detects immediate win after removal in three-men variant', () => {
+    const b = Array(9).fill(0);
+    b[0]=b[1]=-1;
+    assert.strictEqual(winnerAfterRemoval(b,1,'three','moving'), 1);
   });
 
   it('detects no legal moves', () => {

--- a/apps/src/daadi/rules.ts
+++ b/apps/src/daadi/rules.ts
@@ -60,15 +60,15 @@ export const enterMoving = (
 
 /**
  * Immediate win check after removing a piece.
- * Only applies outside the placing phase in the nine-men variant.
+ * Applies outside the placing phase for all variants.
  */
 export const winnerAfterRemoval = (
   board: number[],
   remover: P,
-  variantKey: K,
+  _variantKey: K,
   phase: Phase,
 ): P | 0 => {
-  if (phase !== 'placing' && variantKey === 'nine') {
+  if (phase !== 'placing') {
     const opponent = remover === 1 ? -1 : 1;
     if (board.filter((v) => v === opponent).length <= 2) {
       return remover;
@@ -107,23 +107,22 @@ export const checkWin = (
   variantKey: K,
   flying: boolean,
 ): P | 0 => {
-  const my = toMove;
-  const opponent = -my as P;
-  const myCount = board.filter((v) => v === my).length;
-  const oppCount = board.filter((v) => v === opponent).length;
+  const player = toMove;
+  const opponent = -player as P;
+  const playerCount = board.filter((v) => v === player).length;
 
-  if (phase !== 'placing' && variantKey === 'nine' && oppCount <= 2) {
-    return my;
+  if (phase !== 'placing' && playerCount <= 2) {
+    return opponent;
   }
 
-  const canFly = flying && variantKey === 'nine' && myCount === 3;
+  const canFly = flying && variantKey === 'nine' && playerCount === 3;
   let hasMove = false;
 
   if (canFly) {
     hasMove = board.some((v) => v === 0);
   } else {
     for (let i = 0; i < board.length; i++) {
-      if (board[i] === my && variant.adj[i].some((n) => board[n] === 0)) {
+      if (board[i] === player && variant.adj[i].some((n) => board[n] === 0)) {
         hasMove = true;
         break;
       }


### PR DESCRIPTION
## Summary
- Ensure removing a piece checks for victory across all variants
- Correct win detection to evaluate the player whose turn it is
- Add tests for piece-count losses and three-men variant removal

## Testing
- `npm --prefix apps test`

------
https://chatgpt.com/codex/tasks/task_e_68a6c473153c8324bc9baffb57f1ba76