### PR TITLE
Add project README and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 LazySPA contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
-# Lazy SPA
-These single page apps are lazily created using AI and some sugar!
+# LazySPA
+
+LazySPA (pronounced "spa") is a collection of single-page applications lazily assembled using AI and a bit of sugar. It serves as an experimental playground for building turn-based fun games that can scale with AI-driven development.
+
+## Vision
+We want to build a growing lineup of turn-based games that are fun, accessible, and easy to iterate on. By leaning on AI to generate and evolve these apps, we aim to create many small games that people can play right in their browser.
+
+## Development
+Each app is generated and refined with AI tooling and modern web tech such as Vite, React, and Tailwind CSS. The goal is to keep development light-weight and fast so new ideas can be prototyped quickly.
+
+## License
+LazySPA is released under the MIT License. See [LICENSE](LICENSE) for more information.
 
 ## Deployment
-
 The `main` branch is automatically built and deployed to the `gh-pages` branch via GitHub Actions.


### PR DESCRIPTION
## Summary
- expand README to describe LazySPA, its vision for AI-driven turn-based games, development approach, and licensing
- add MIT license file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c60d71848324b641791910e112b9