### PR TITLE
feat: modernize UI with dark mode

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Daadi • Navakankari</title>
   </head>
-  <body class="bg-zinc-50">
+  <body class="bg-zinc-50 dark:bg-zinc-900">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/apps/src/App.tsx
+++ b/apps/src/App.tsx
@@ -2,7 +2,7 @@ import Gameplay from './daadi/Gameplay'
 
 export default function App() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-zinc-100 to-zinc-300 text-zinc-800 flex items-center justify-center py-4">
+    <div className="min-h-screen bg-gradient-to-br from-zinc-100 to-zinc-300 dark:from-zinc-900 dark:to-zinc-700 text-zinc-800 dark:text-zinc-100">
       <Gameplay />
     </div>
   )

--- a/apps/src/daadi/Gameplay.tsx
+++ b/apps/src/daadi/Gameplay.tsx
@@ -31,6 +31,9 @@ export default function Gameplay(){
   const [p2Name,setP2Name]=useState("CPU");
   const [p1Color,setP1Color]=useState("#0f0f0f");
   const [p2Color,setP2Color]=useState("#ffffff");
+  const [dark,setDark]=useState(false);
+  useEffect(()=>{const s=localStorage.getItem('theme');if(s==='dark')setDark(true);},[]);
+  useEffect(()=>{document.documentElement.classList.toggle('dark',dark);localStorage.setItem('theme',dark?'dark':'light');},[dark]);
   type Snap={board:number[];turn:P;phase:Phase;toPlace:{p1:number;p2:number};sel:number|null;mustRem:P|null;flying:boolean;last:{from:number|null;to:number|null}|null;msg:string;ply:number};
   const [hist,setHist]=useState<Snap[]>([]);const push=()=>setHist(h=>[...h,{board:[...board],turn,phase,toPlace:{...toPlace},sel,mustRem,flying,last: last?{...last}:null,msg,ply}]);
   const undo=()=>setHist(h=>{if(!h.length)return h;const s=h[h.length-1];setBoard(s.board);setTurn(s.turn);setPhase(s.phase);setTP(s.toPlace);setSel(s.sel);setMustRem(s.mustRem);setFlying(s.flying);setLast(s.last);setMsg(s.msg);setPly(s.ply);setWinner(0);return h.slice(0,-1)});
@@ -100,107 +103,111 @@ export default function Gameplay(){
   const remSet=useMemo(()=>mustRem===null?new Set<number>():removables(board,mustRem,VARIANTS[vk].mills),[board,mustRem,vk]);
   const Title= vk==='nine'? 'Daadi • Navakankari' : 'Chinna Daadi';
 
-  return (<div className="min-h-screen w-full bg-white/70 backdrop-blur flex flex-col items-center py-6 text-zinc-900">
-    <div className="w-full max-w-6xl px-2 sm:px-4 mb-4">
-      <div className="flex items-center justify-between">
-        <a href="/" className="text-sm px-3 py-1.5 rounded-lg bg-white border border-zinc-300 hover:bg-zinc-100">🏠 Home</a>
+  return (
+    <div className="min-h-screen w-full flex flex-col">
+      <header className="w-full px-4 py-2 flex items-center justify-between bg-white/80 dark:bg-zinc-800/80 backdrop-blur shadow">
         <div className="flex items-center gap-2">
-          <span className="text-2xl font-semibold" onClick={(e:any)=>{ if(e.detail===3){ const t = !dbg; setDbg(t); setMsg(`Debug mode: ${t ? 'ON' : 'OFF'} (triple‑click title to toggle)`);} }}>🇮🇳 {Title}</span>
+          <span className="text-xl font-semibold" onClick={(e:any)=>{ if(e.detail===3){ const t = !dbg; setDbg(t); setMsg(`Debug mode: ${t ? 'ON' : 'OFF'} (triple‑click title to toggle)`);} }}>{Title}</span>
           {dbg && <span className="text-xs px-2 py-0.5 rounded bg-yellow-100 text-yellow-800">Debug</span>}
         </div>
-        <div className="w-16" />
-      </div>
-    </div>
+        <div className="hidden sm:flex items-center gap-4 text-sm">
+          <span className="capitalize">{phase==='placing'?"Placing":phase==='moving'?"Moving":mustRem!==null?"Removing":"Game Over"}</span>
+          <span>Turn: {nameOf(turn)}</span>
+          <span>Move: {ply}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button onClick={undo} className="text-sm px-3 py-1.5 rounded-lg border border-zinc-300 bg-white hover:bg-zinc-100 dark:bg-zinc-700 dark:border-zinc-600 dark:hover:bg-zinc-600">Undo</button>
+          <button onClick={()=>reset(true)} className="text-sm px-3 py-1.5 rounded-lg bg-zinc-900 text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200">Reset</button>
+          <button onClick={()=>setDark(d=>!d)} className="text-sm px-3 py-1.5 rounded-lg border border-zinc-300 bg-white hover:bg-zinc-100 dark:bg-zinc-700 dark:border-zinc-600 dark:hover:bg-zinc-600">{dark?"Light":"Dark"}</button>
+        </div>
+      </header>
 
-    <div className="grid grid-cols-1 md:grid-cols-[auto_320px] gap-6 w-full max-w-6xl px-2 sm:px-4">
-      <div className="bg-white rounded-2xl shadow p-2 sm:p-4 md:p-6">
-        <svg viewBox={`0 0 ${off*2+6*sx} ${off*2+6*sx}`} className="w-full h-auto text-zinc-700 touch-manipulation select-none">
-          <g>{VARIANTS[vk].drawLines(sx,off)}</g>
-          {VARIANTS[vk].points.map((p,i)=>{const {cx,cy}=toXY(p);const o=board[i];const seld=sel===i;const lastHit=last&&(last.from===i||last.to===i);const canGo=sel!==null&&legal(sel,turn).includes(i);const canPlaceHere=phase==='placing'&&board[i]===0&&mustRem===null&&(turn===1||!cpu)&&canPlace(toPlace,turn)&&!dbg;const canRem=mustRem!==null&&remSet.has(i)&&board[i]===(mustRem===1?-1:1);const inM=o===1?mill1.has(i):o===-1?mill2.has(i):false;return (
-            <g key={i} onClick={()=>click(i)} className={cpu&&turn===-1?"cursor-not-allowed":"cursor-pointer"}>
-              {board[i]===0&&(canGo||canPlaceHere)&&<circle cx={cx} cy={cy} r={18} className="fill-emerald-200/50"/>}
-              {o!==0&&<circle cx={cx} cy={cy} r={18} className={`stroke-zinc-900 stroke-[1.5px]${seld?" ring-4 ring-blue-300":""}${canRem?" ring-4 ring-rose-300":""}`} style={{fill:colorOf(o as P)}}/>}
-              {o===0&&<circle cx={cx} cy={cy} r={7} className="fill-zinc-700"/>}
-              {inM&&<circle cx={cx} cy={cy} r={4} className="fill-amber-400"/>}
-              {lastHit&&<circle cx={cx} cy={cy} r={22} className="fill-transparent stroke-blue-400 stroke-2"/>}
-            </g>)})}
-        </svg>
-      </div>
-
-      <div className="flex flex-col gap-4">
-        <div className="bg-white rounded-2xl shadow p-4">
-          <div className="flex items-center justify-between gap-2 flex-wrap"><span className="text-lg font-semibold">Status</span><div className="flex items-center gap-2"><button onClick={undo} className="text-sm px-3 py-1.5 rounded-lg bg-white border border-zinc-300 hover:bg-zinc-100">Undo</button><button onClick={()=>reset(true)} className="text-sm px-3 py-1.5 rounded-lg bg-zinc-900 text-white hover:bg-zinc-800">Reset</button></div></div>
-          <div className="mt-3 text-sm leading-relaxed">
-            <div className="mb-2"><span className="px-2 py-1 rounded bg-zinc-100 mr-2">Phase</span><span className="font-medium capitalize">{phase==='placing'?"Placing":phase==='moving'?"Moving":mustRem!==null?"Removing":"Game Over"}</span></div>
-            <div className="mb-2 flex items-center gap-2"><span className="px-2 py-1 rounded bg-zinc-100">Turn</span><span className={`font-semibold ${turn===1?"text-zinc-900":"text-zinc-600"}`}>{nameOf(turn)}</span></div>
-            <div className="mb-2"><span className="px-2 py-1 rounded bg-zinc-100 mr-2">Move</span><span className="font-medium">{ply}</span></div>
-            <p className="text-zinc-700">{msg}</p>
-          </div>
-          <div className="mt-3 flex flex-col gap-2 text-sm text-zinc-600">
-            <div className="flex items-center gap-2"><span className="w-3 h-3 rounded-full border" style={{background:p1Color}}></span>{p1Name} on board: {counts.p1} &nbsp; to place: {toPlace.p1}</div>
-            <div className="flex items-center gap-2"><span className="w-3 h-3 rounded-full border" style={{background:p2Color}}></span>{p2Name} on board: {counts.p2} &nbsp; to place: {toPlace.p2}</div>
+      <div className="flex-1 w-full flex flex-col md:flex-row items-start gap-6 p-4 max-w-6xl mx-auto">
+        <div className="flex-1 flex items-center justify-center">
+          <div className="bg-white dark:bg-zinc-800 rounded-2xl shadow p-2 sm:p-4 md:p-6">
+            <svg viewBox={`0 0 ${off*2+6*sx} ${off*2+6*sx}`} className="w-full h-auto text-zinc-700 dark:text-zinc-300 touch-manipulation select-none">
+              <g>{VARIANTS[vk].drawLines(sx,off)}</g>
+              {VARIANTS[vk].points.map((p,i)=>{const {cx,cy}=toXY(p);const o=board[i];const seld=sel===i;const lastHit=last&&(last.from===i||last.to===i);const canGo=sel!==null&&legal(sel,turn).includes(i);const canPlaceHere=phase==='placing'&&board[i]===0&&mustRem===null&&(turn===1||!cpu)&&canPlace(toPlace,turn)&&!dbg;const canRem=mustRem!==null&&remSet.has(i)&&board[i]===(mustRem===1?-1:1);const inM=o===1?mill1.has(i):o===-1?mill2.has(i):false;return (
+                <g key={i} onClick={()=>click(i)} className={cpu&&turn===-1?"cursor-not-allowed":"cursor-pointer"}>
+                  {board[i]===0&&(canGo||canPlaceHere)&&<circle cx={cx} cy={cy} r={18} className="fill-emerald-200/50"/>}
+                  {o!==0&&<circle cx={cx} cy={cy} r={18} className={`stroke-zinc-900 dark:stroke-zinc-200 stroke-[1.5px]${seld?" ring-4 ring-blue-300":""}${canRem?" ring-4 ring-rose-300":""}`} style={{fill:colorOf(o as P)}}/>}
+                  {o===0&&<circle cx={cx} cy={cy} r={7} className="fill-zinc-700 dark:fill-zinc-400"/>}
+                  {inM&&<circle cx={cx} cy={cy} r={4} className="fill-amber-400"/>}
+                  {lastHit&&<circle cx={cx} cy={cy} r={22} className="fill-transparent stroke-blue-400 dark:stroke-blue-300 stroke-2"/>}
+                </g>)})}
+            </svg>
           </div>
         </div>
 
-        <div className="bg-white rounded-2xl shadow p-4">
-          <div className="flex items-center justify-between gap-2"><span className="text-lg font-semibold">Options</span>{dbg && (<button onClick={()=>setTests(runTests())} className="text-xs px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100">Run tests</button>)}</div>
-          <div className="mt-3 text-sm space-y-3">
-            <label className="flex items-center gap-2 select-none"><input type="checkbox" checked={cpu} onChange={e=>{setCPU(e.target.checked); if(e.target.checked) setP2Name('CPU'); else if(p2Name==='CPU') setP2Name('Player 2');}}/><span>CPU as Player 2</span></label>
-            {vk==='nine'&&<label className="flex items-center gap-2 select-none"><input type="checkbox" checked={flying} onChange={e=>setFlying(e.target.checked)}/><span>Allow flying at 3</span></label>}
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <input type="color" value={p1Color} onChange={e=>setP1Color(e.target.value)} className="h-8 w-8 p-0 border rounded"/>
-                <input type="text" value={p1Name} onChange={e=>setP1Name(e.target.value)} className="flex-1 border rounded px-2 py-1"/>
-              </div>
-              <div className="flex items-center gap-2">
-                <input type="color" value={p2Color} onChange={e=>setP2Color(e.target.value)} className="h-8 w-8 p-0 border rounded"/>
-                <input type="text" value={p2Name} onChange={e=>setP2Name(e.target.value)} disabled={cpu} className="flex-1 border rounded px-2 py-1 disabled:opacity-50"/>
-              </div>
-              <button onClick={()=>{setP1Color(p2Color);setP2Color(p1Color);}} className="text-xs px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100">Swap colors</button>
+        <div className="w-full md:w-80 flex flex-col gap-4">
+          <div className="bg-white dark:bg-zinc-800 rounded-2xl shadow p-4">
+            <p className="text-sm leading-relaxed">{msg}</p>
+            <div className="mt-3 flex flex-col gap-2 text-sm text-zinc-600 dark:text-zinc-400">
+              <div className="flex items-center gap-2"><span className="w-3 h-3 rounded-full border" style={{background:p1Color}}></span>{p1Name} on board: {counts.p1} &nbsp; to place: {toPlace.p1}</div>
+              <div className="flex items-center gap-2"><span className="w-3 h-3 rounded-full border" style={{background:p2Color}}></span>{p2Name} on board: {counts.p2} &nbsp; to place: {toPlace.p2}</div>
             </div>
-            {dbg && (<label className="flex items-center gap-2 select-none"><input type="checkbox" checked={dbg} onChange={e=>setDbg(e.target.checked)}/><span>Test / Debug mode</span></label>)}
-            {dbg&&<div className="ml-5 space-y-2">
-              <div className="flex items-center gap-3"><span className="text-zinc-600">Place as:</span><label className="flex items-center gap-1"><input type="radio" name="dbgActor" checked={dbgActor===1} onChange={()=>setDbgActor(1)}/><span>Player 1</span></label><label className="flex items-center gap-1"><input type="radio" name="dbgActor" checked={dbgActor===-1} onChange={()=>setDbgActor(-1)}/><span>Player 2</span></label></div>
-              <div className="flex gap-2"><button onClick={()=>{setBoard(Array(VARIANTS[vk].points.length).fill(0));setSel(null);setMustRem(null)}} className="px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100">Clear board</button><button onClick={()=>{setPhase('moving');setTP({p1:0,p2:0});setMustRem(null);setMsg('Debug: entered moving phase.')}} className="px-2 py-1 rounded bg-zinc-900 text-white hover:bg-zinc-800">Start from current position</button><button onClick={()=>setTurn(t=>-t as P)} className="px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100">Swap turn</button></div>
+          </div>
+
+          <div className="bg-white dark:bg-zinc-800 rounded-2xl shadow p-4">
+            <div className="flex items-center justify-between gap-2"><span className="text-lg font-semibold">Options</span>{dbg && (<button onClick={()=>setTests(runTests())} className="text-xs px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100 dark:border-zinc-600 dark:hover:bg-zinc-700">Run tests</button>)}</div>
+            <div className="mt-3 text-sm space-y-3">
+              <label className="flex items-center gap-2 select-none"><input type="checkbox" checked={cpu} onChange={e=>{setCPU(e.target.checked); if(e.target.checked) setP2Name('CPU'); else if(p2Name==='CPU') setP2Name('Player 2');}}/><span>CPU as Player 2</span></label>
+              {vk==='nine'&&<label className="flex items-center gap-2 select-none"><input type="checkbox" checked={flying} onChange={e=>setFlying(e.target.checked)}/><span>Allow flying at 3</span></label>}
               <div className="space-y-2">
-                <div className="flex gap-2">
-                  <button onClick={async()=>{try{await navigator.clipboard.writeText(stateStr);setMsg('Debug: state copied to clipboard');}catch(e){setMsg('Debug: copy failed');}}} className="px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100">Copy state</button>
-                  <button onClick={()=>{console.log('DAADI_STATE',{variant:vk,board,turn,phase,toPlace,mustRem,flying});setMsg('Debug: state logged to console');}} className="px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100">Log state</button>
+                <div className="flex items-center gap-2">
+                  <input type="color" value={p1Color} onChange={e=>setP1Color(e.target.value)} className="h-8 w-8 p-0 border rounded"/>
+                  <input type="text" value={p1Name} onChange={e=>setP1Name(e.target.value)} className="flex-1 border rounded px-2 py-1"/>
                 </div>
-                <textarea readOnly value={stateStr} rows={4} className="w-full border rounded p-2 text-xs font-mono bg-zinc-50"/>
+                <div className="flex items-center gap-2">
+                  <input type="color" value={p2Color} onChange={e=>setP2Color(e.target.value)} className="h-8 w-8 p-0 border rounded"/>
+                  <input type="text" value={p2Name} onChange={e=>setP2Name(e.target.value)} disabled={cpu} className="flex-1 border rounded px-2 py-1 disabled:opacity-50"/>
+                </div>
+                <button onClick={()=>{setP1Color(p2Color);setP2Color(p1Color);}} className="text-xs px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100 dark:border-zinc-600 dark:hover:bg-zinc-700">Swap colors</button>
               </div>
-              <p className="text-xs text-zinc-500">Click any point to place/remove without phase rules.</p>
-            </div>}
-            <div className="flex items-center gap-2"><span className="w-20 shrink-0 text-zinc-600">Variant</span><select value={vk} onChange={e=>setVk(e.target.value as K)} className="border rounded px-2 py-1 w-full"><option value="nine">Nine Men's Morris</option><option value="three">Three Men's Morris (Chinna Daadi)</option></select></div>
-          </div>
-          {tests&&<div className="mt-3 text-sm"><div className="font-medium mb-1">Test Results</div><ul className="list-disc pl-5 space-y-1">{tests.map((t,i)=>(<li key={i} className={t.pass?"text-emerald-700":"text-rose-700"}>{t.pass?"✔":"✘"} {t.name}</li>))}</ul></div>}
-        </div>
-
-        <div className="bg-white rounded-2xl shadow p-4">
-          <details className="group" open>
-            <summary className="flex items-center justify-between text-base font-medium cursor-pointer select-none"><span>Rules & How to Play</span><span className="text-xs px-2 py-0.5 rounded bg-zinc-100 group-open:hidden">show</span><span className="text-xs px-2 py-0.5 rounded bg-zinc-100 hidden group-open:inline">hide</span></summary>
-            <div className="mt-2 text-sm text-zinc-700 space-y-2">
-              <ul className="list-disc pl-5 space-y-1">
-                <li>Each player gets <b>{VARIANTS[vk].initialPieces}</b> pieces.</li>
-                <li><b>Placing:</b> Place on any empty point. Making a mill (3 in a row) lets you remove one opponent piece (prefer pieces not in mills).</li>
-                <li><b>Moving:</b> After all pieces are placed, move along connected lines{vk==='nine'&&flying?", or fly anywhere when at 3 pieces":""}.</li>
-                <li><b>Win:</b> (Not during placing) reduce opponent to 2 or leave them with no legal move.</li>
-              </ul>
-              <div className="pt-2 border-t text-zinc-600"><p className="font-medium mb-1">Tips</p><ul className="list-disc pl-5 space-y-1"><li>Set up double threats.</li><li>Block while developing.</li><li>Keep pieces connected.</li></ul></div>
+              {dbg && (<label className="flex items-center gap-2 select-none"><input type="checkbox" checked={dbg} onChange={e=>setDbg(e.target.checked)}/><span>Test / Debug mode</span></label>)}
+              {dbg&&<div className="ml-5 space-y-2">
+                <div className="flex items-center gap-3"><span className="text-zinc-600 dark:text-zinc-400">Place as:</span><label className="flex items-center gap-1"><input type="radio" name="dbgActor" checked={dbgActor===1} onChange={()=>setDbgActor(1)}/><span>Player 1</span></label><label className="flex items-center gap-1"><input type="radio" name="dbgActor" checked={dbgActor===-1} onChange={()=>setDbgActor(-1)}/><span>Player 2</span></label></div>
+                <div className="flex gap-2"><button onClick={()=>{setBoard(Array(VARIANTS[vk].points.length).fill(0));setSel(null);setMustRem(null)}} className="px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100 dark:border-zinc-600 dark:hover:bg-zinc-700">Clear board</button><button onClick={()=>{setPhase('moving');setTP({p1:0,p2:0});setMustRem(null);setMsg('Debug: entered moving phase.')}} className="px-2 py-1 rounded bg-zinc-900 text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200">Start from current position</button><button onClick={()=>setTurn(t=>-t as P)} className="px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100 dark:border-zinc-600 dark:hover:bg-zinc-700">Swap turn</button></div>
+                <div className="space-y-2">
+                  <div className="flex gap-2">
+                    <button onClick={async()=>{try{await navigator.clipboard.writeText(stateStr);setMsg('Debug: state copied to clipboard');}catch(e){setMsg('Debug: copy failed');}}} className="px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100 dark:border-zinc-600 dark:hover:bg-zinc-700">Copy state</button>
+                    <button onClick={()=>{console.log('DAADI_STATE',{variant:vk,board,turn,phase,toPlace,mustRem,flying});setMsg('Debug: state logged to console');}} className="px-2 py-1 rounded border border-zinc-300 hover:bg-zinc-100 dark:border-zinc-600 dark:hover:bg-zinc-700">Log state</button>
+                  </div>
+                  <textarea readOnly value={stateStr} rows={4} className="w-full border rounded p-2 text-xs font-mono bg-zinc-50 dark:bg-zinc-900"/>
+                </div>
+                <p className="text-xs text-zinc-500 dark:text-zinc-400">Click any point to place/remove without phase rules.</p>
+              </div>}
+              <div className="flex items-center gap-2"><span className="w-20 shrink-0 text-zinc-600 dark:text-zinc-400">Variant</span><select value={vk} onChange={e=>setVk(e.target.value as K)} className="border rounded px-2 py-1 w-full"><option value="nine">Nine Men's Morris</option><option value="three">Three Men's Morris (Chinna Daadi)</option></select></div>
             </div>
-          </details>
+            {tests&&<div className="mt-3 text-sm"><div className="font-medium mb-1">Test Results</div><ul className="list-disc pl-5 space-y-1">{tests.map((t,i)=>(<li key={i} className={t.pass?"text-emerald-700":"text-rose-700"}>{t.pass?"✔":"✘"} {t.name}</li>))}</ul></div>}
+          </div>
+
+          <div className="bg-white dark:bg-zinc-800 rounded-2xl shadow p-4">
+            <details className="group" open>
+              <summary className="flex items-center justify-between text-base font-medium cursor-pointer select-none"><span>Rules & How to Play</span><span className="text-xs px-2 py-0.5 rounded bg-zinc-100 group-open:hidden dark:bg-zinc-700">show</span><span className="text-xs px-2 py-0.5 rounded bg-zinc-100 hidden group-open:inline dark:bg-zinc-700">hide</span></summary>
+              <div className="mt-2 text-sm text-zinc-700 dark:text-zinc-300 space-y-2">
+                <ul className="list-disc pl-5 space-y-1">
+                  <li>Each player gets <b>{VARIANTS[vk].initialPieces}</b> pieces.</li>
+                  <li><b>Placing:</b> Place on any empty point. Making a mill (3 in a row) lets you remove one opponent piece (prefer pieces not in mills).</li>
+                  <li><b>Moving:</b> After all pieces are placed, move along connected lines{vk==='nine'&&flying?", or fly anywhere when at 3 pieces":""}.</li>
+                  <li><b>Win:</b> (Not during placing) reduce opponent to 2 or leave them with no legal move.</li>
+                </ul>
+                <div className="pt-2 border-t text-zinc-600 dark:text-zinc-400"><p className="font-medium mb-1">Tips</p><ul className="list-disc pl-5 space-y-1"><li>Set up double threats.</li><li>Block while developing.</li><li>Keep pieces connected.</li></ul></div>
+              </div>
+            </details>
+          </div>
         </div>
       </div>
+
+      <footer className="mt-6 text-xs text-center text-zinc-500 dark:text-zinc-400">Built with ❤️ – Daadi (Navakankari) & Chinna Daadi</footer>
+
+      {winner!==0&&(<div className="fixed inset-0 bg-black/30 dark:bg-black/60 flex items-center justify-center p-4 z-50"><div className="bg-white dark:bg-zinc-800 rounded-2xl shadow-xl p-6 w-full max-w-sm text-center relative overflow-hidden">
+        <style>{`@keyframes blink{0%,80%,100%{opacity:.25}40%{opacity:1}}@keyframes dash{from{stroke-dashoffset:140}to{stroke-dashoffset:0}}`}</style>
+        <div className="flex items-center justify-center mb-3"><svg width="180" height="40" viewBox="0 0 180 40">{(()=>{const isP1=winner===1;const d=colorOf(isP1?1:-1);const common:any={r:6};return(<g><circle cx="20" cy="20" {...common} fill={d} stroke="#0f0f0f" style={{animation:"blink 1.2s infinite" as any}}/><circle cx="90" cy="20" {...common} fill={d} stroke="#0f0f0f" style={{animation:"blink 1.2s .2s infinite" as any}}/><circle cx="160" cy="20" {...common} fill={d} stroke="#0f0f0f" style={{animation:"blink 1.2s .4s infinite" as any}}/><line x1="26" y1="20" x2="84" y2="20" stroke={d} strokeWidth="3" strokeDasharray="140" strokeDashoffset="140" style={{animation:"dash 1.2s ease forwards" as any}}/><line x1="96" y1="20" x2="154" y2="20" stroke={d} strokeWidth="3" strokeDasharray="140" strokeDashoffset="140" style={{animation:"dash 1.2s .2s ease forwards" as any}}/></g>)})()}</svg></div>
+        <div className="text-2xl font-semibold mb-1">🏆 {nameOf(winner as P)} wins!</div>
+        <p className="text-sm text-zinc-600 dark:text-zinc-300 mb-4">Good game.</p>
+        <button onClick={()=>reset(true)} className="px-4 py-2 rounded-lg bg-zinc-900 text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200">New game</button>
+      </div></div>)}
     </div>
-
-    <footer className="mt-6 text-xs text-zinc-500">Built with ❤️ – Daadi (Navakankari) & Chinna Daadi</footer>
-
-    {winner!==0&&(<div className="fixed inset-0 bg-black/30 flex items-center justify-center p-4 z-50"><div className="bg-white rounded-2xl shadow-xl p-6 w-full max-w-sm text-center relative overflow-hidden">
-      <style>{`@keyframes blink{0%,80%,100%{opacity:.25}40%{opacity:1}}@keyframes dash{from{stroke-dashoffset:140}to{stroke-dashoffset:0}}`}</style>
-      <div className="flex items-center justify-center mb-3"><svg width="180" height="40" viewBox="0 0 180 40">{(()=>{const isP1=winner===1;const d=colorOf(isP1?1:-1);const common:any={r:6};return(<g><circle cx="20" cy="20" {...common} fill={d} stroke="#0f0f0f" style={{animation:"blink 1.2s infinite" as any}}/><circle cx="90" cy="20" {...common} fill={d} stroke="#0f0f0f" style={{animation:"blink 1.2s .2s infinite" as any}}/><circle cx="160" cy="20" {...common} fill={d} stroke="#0f0f0f" style={{animation:"blink 1.2s .4s infinite" as any}}/><line x1="26" y1="20" x2="84" y2="20" stroke={d} strokeWidth="3" strokeDasharray="140" strokeDashoffset="140" style={{animation:"dash 1.2s ease forwards" as any}}/><line x1="96" y1="20" x2="154" y2="20" stroke={d} strokeWidth="3" strokeDasharray="140" strokeDashoffset="140" style={{animation:"dash 1.2s .2s ease forwards" as any}}/></g>)})()}</svg></div>
-      <div className="text-2xl font-semibold mb-1">🏆 {nameOf(winner as P)} wins!</div>
-      <p className="text-sm text-zinc-600 mb-4">Good game.</p>
-      <button onClick={()=>reset(true)} className="px-4 py-2 rounded-lg bg-zinc-900 text-white hover:bg-zinc-800">New game</button>
-    </div></div>)}
-  </div>);
+  );
 }

--- a/apps/tailwind.config.js
+++ b/apps/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{ts,tsx,js,jsx}",


### PR DESCRIPTION
## Summary
- add dark/off-gray theme via Tailwind class mode
- rebuild gameplay layout with top header, modern panels, and dark mode toggle
- adjust app shell for new styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6cbb88db883249d5bb8a4b99d8e17