### PR TITLE
feat: add Playwright render tests

### DIFF
--- a/.github/workflows/render-test.yml
+++ b/.github/workflows/render-test.yml
@@ -1,0 +1,31 @@
+name: Render Tests
+
+on:
+  pull_request:
+    paths:
+      - 'apps/**'
+      - '.github/workflows/render-test.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - run: npx playwright install --with-deps
+      - run: npm run test:playwright
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-screenshots
+          path: apps/test-results
+          if-no-files-found: ignore

--- a/.github/workflows/render-test.yml
+++ b/.github/workflows/render-test.yml
@@ -21,7 +21,7 @@ jobs:
           cache-dependency-path: apps/package-lock.json
       - run: npm ci
       - run: npm run build
-      - run: npx playwright install --with-deps
+      - run: npx -p @playwright/test playwright install --with-deps
       - run: npm run test:playwright
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/render-test.yml
+++ b/.github/workflows/render-test.yml
@@ -21,7 +21,7 @@ jobs:
           cache-dependency-path: apps/package-lock.json
       - run: npm ci
       - run: npm run build
-      - run: npx -p @playwright/test playwright install --with-deps
+      - run: npx playwright install --with-deps
       - run: npm run test:playwright
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
 dist/
-test-results/
+**/test-results/

--- a/README.md
+++ b/README.md
@@ -4,3 +4,14 @@ These single page apps are lazily created using AI and some sugar!
 ## Deployment
 
 The `main` branch is automatically built and deployed to the `gh-pages` branch via GitHub Actions.
+
+## Testing
+
+End-to-end render tests are powered by [Playwright](https://playwright.dev/). To run them locally:
+
+```bash
+cd apps
+npm run test:playwright
+```
+
+During pull requests a workflow runs these tests and uploads page screenshots as build artifacts.

--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+        "@playwright/test": "^1.24.0",
         "@types/node": "^24.3.0",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
@@ -839,6 +840,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3531,6 +3548,53 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/apps/package.json
+++ b/apps/package.json
@@ -25,6 +25,7 @@
     "tailwindcss": "^3.4.9",
     "typescript": "^5.4.5",
     "vite": "^5.0.0",
-    "vite-plugin-node-polyfills": "^0.24.0"
+    "vite-plugin-node-polyfills": "^0.24.0",
+    "@playwright/test": "^1.24.0"
   }
 }

--- a/apps/package.json
+++ b/apps/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "tsc -p tsconfig.test.json && echo '{\"type\":\"commonjs\"}' > dist/package.json && node --test dist/**/*.test.js",
-    "test:playwright": "npx -p @playwright/test playwright test"
+    "test:playwright": "playwright test"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -25,6 +25,7 @@
     "tailwindcss": "^3.4.9",
     "typescript": "^5.4.5",
     "vite": "^5.0.0",
-    "vite-plugin-node-polyfills": "^0.24.0"
+    "vite-plugin-node-polyfills": "^0.24.0",
+    "@playwright/test": "^1.55.0"
   }
 }

--- a/apps/package.json
+++ b/apps/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "tsc -p tsconfig.test.json && echo '{\"type\":\"commonjs\"}' > dist/package.json && node --test dist/**/*.test.js",
-    "test:playwright": "playwright test"
+    "test:playwright": "npx -p @playwright/test playwright test"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -25,7 +25,6 @@
     "tailwindcss": "^3.4.9",
     "typescript": "^5.4.5",
     "vite": "^5.0.0",
-    "vite-plugin-node-polyfills": "^0.24.0",
-    "@playwright/test": "^1.55.0"
+    "vite-plugin-node-polyfills": "^0.24.0"
   }
 }

--- a/apps/package.json
+++ b/apps/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsc -p tsconfig.test.json && echo '{\"type\":\"commonjs\"}' > dist/package.json && node --test dist/**/*.test.js"
+    "test": "tsc -p tsconfig.test.json && echo '{\"type\":\"commonjs\"}' > dist/package.json && node --test dist/**/*.test.js",
+    "test:playwright": "npx playwright test"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -24,6 +25,7 @@
     "tailwindcss": "^3.4.9",
     "typescript": "^5.4.5",
     "vite": "^5.0.0",
-    "vite-plugin-node-polyfills": "^0.24.0"
+    "vite-plugin-node-polyfills": "^0.24.0",
+    "@playwright/test": "^1.45.0"
   }
 }

--- a/apps/package.json
+++ b/apps/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "tsc -p tsconfig.test.json && echo '{\"type\":\"commonjs\"}' > dist/package.json && node --test dist/**/*.test.js",
-    "test:playwright": "npx playwright test"
+    "test:playwright": "npx -p @playwright/test playwright test"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -25,7 +25,6 @@
     "tailwindcss": "^3.4.9",
     "typescript": "^5.4.5",
     "vite": "^5.0.0",
-    "vite-plugin-node-polyfills": "^0.24.0",
-    "@playwright/test": "^1.45.0"
+    "vite-plugin-node-polyfills": "^0.24.0"
   }
 }

--- a/apps/playwright.config.js
+++ b/apps/playwright.config.js
@@ -1,6 +1,4 @@
-import { defineConfig } from '@playwright/test';
-
-export default defineConfig({
+const config = {
   testDir: './tests',
   webServer: {
     command: 'npm run preview',
@@ -10,4 +8,6 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:4173',
   },
-});
+};
+
+export default config;

--- a/apps/playwright.config.ts
+++ b/apps/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npm run preview',
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:4173',
+  },
+});

--- a/apps/tests/render.spec.ts
+++ b/apps/tests/render.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('home page renders correctly', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('body')).toBeVisible();
+  await page.screenshot({ path: 'test-results/home.png', fullPage: true });
+});

--- a/apps/tests/render.spec.ts
+++ b/apps/tests/render.spec.ts
@@ -2,6 +2,6 @@ import { test, expect } from '@playwright/test';
 
 test('home page renders correctly', async ({ page }) => {
   await page.goto('/');
-  await expect(page.locator('body')).toBeVisible();
+  await expect(page.getByText('Rules & How to Play')).toBeVisible();
   await page.screenshot({ path: 'test-results/home.png', fullPage: true });
 });


### PR DESCRIPTION
## Summary
- add Playwright dependency and script for rendering tests
- configure Playwright and add basic home page screenshot test
- run Playwright tests in PRs and upload screenshots as artifacts
- run Playwright tests via npx to avoid missing CLI errors

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npm run build`
- `npm run test:playwright` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c760f6048324acd0385da3163ed9