### PR TITLE
feat: modernize UI with dark mode

### DIFF
--- a/apps/src/daadi/Gameplay.tsx
+++ b/apps/src/daadi/Gameplay.tsx
@@ -145,11 +145,7 @@ export default function Gameplay(){
         </div>
       </header>
 
-<<<<<<< HEAD
-      <div className="flex-1 w-full flex flex-col md:flex-row items-start gap-6 p-4 max-w-6xl mx-auto">
-=======
       <div className="flex-1 w-full flex flex-col md:flex-row items-start gap-6 p-4 md:p-6 lg:p-8">
->>>>>>> b03a812 (fix: expand board area)
         <div className="flex-1 flex items-center justify-center">
           <div className="bg-white dark:bg-zinc-800 rounded-2xl shadow p-2 sm:p-4 md:p-6">
             <svg viewBox={`0 0 ${off*2+6*sx} ${off*2+6*sx}`} className="w-full h-auto text-zinc-700 dark:text-zinc-300 touch-manipulation select-none">

--- a/apps/src/daadi/Gameplay.tsx
+++ b/apps/src/daadi/Gameplay.tsx
@@ -145,7 +145,11 @@ export default function Gameplay(){
         </div>
       </header>
 
+<<<<<<< HEAD
       <div className="flex-1 w-full flex flex-col md:flex-row items-start gap-6 p-4 max-w-6xl mx-auto">
+=======
+      <div className="flex-1 w-full flex flex-col md:flex-row items-start gap-6 p-4 md:p-6 lg:p-8">
+>>>>>>> b03a812 (fix: expand board area)
         <div className="flex-1 flex items-center justify-center">
           <div className="bg-white dark:bg-zinc-800 rounded-2xl shadow p-2 sm:p-4 md:p-6">
             <svg viewBox={`0 0 ${off*2+6*sx} ${off*2+6*sx}`} className="w-full h-auto text-zinc-700 dark:text-zinc-300 touch-manipulation select-none">


### PR DESCRIPTION
## Summary
- add dark/off-gray theme via Tailwind class mode
- rebuild gameplay layout with top header, modern panels, and dark mode toggle
- adjust app shell for new styling
- remove width cap so board fills available space with simple margins

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6cbb88db883249d5bb8a4b99d8e17