### PR TITLE
feat(core): add game and turn management

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,21 @@
+# @lazyspa/core
+
+Utilities for building games and managing turn-based interactions.
+
+## Development
+
+Install dependencies (if any) and run the tests:
+
+```bash
+npm test
+```
+
+This compiles the TypeScript sources and executes the example tests.
+
+To compile without running tests:
+
+```bash
+npm run build
+```
+
+Compiled artifacts will be written to the `dist/` directory.

--- a/packages/core/__tests__/turnManager.test.ts
+++ b/packages/core/__tests__/turnManager.test.ts
@@ -1,0 +1,62 @@
+// @ts-ignore
+import { strict as assert } from 'node:assert';
+import { Game } from '../src/game';
+import { Player, TurnManager } from '../src/player';
+
+type Phase = 'placement' | 'movement' | 'main';
+
+function createDummyPlayer<State, Move>(): Player<State, Move, Phase> {
+  return {
+    type: 'human',
+    getMove: () => ({}) as Move,
+  };
+}
+
+function testPhaseTransition() {
+  interface State { moves: number }
+  type Move = {};
+  const game: Game<State, Move> = {
+    init: () => ({ moves: 0 }),
+    applyMove: (state) => ({ moves: state.moves + 1 }),
+    checkWin: () => false,
+  };
+  const player = createDummyPlayer<State, Move>();
+  const tm = new TurnManager<State, Move, Phase>(
+    game,
+    [player, player],
+    'placement',
+    (state, phase) => (state.moves >= 2 ? 'movement' : phase)
+  );
+
+  tm.playTurn();
+  assert.equal(tm.getPhase(), 'placement');
+
+  tm.playTurn();
+  assert.equal(tm.getPhase(), 'movement');
+}
+
+function testWinDetection() {
+  interface State { moves: number }
+  type Move = {};
+  const game: Game<State, Move> = {
+    init: () => ({ moves: 0 }),
+    applyMove: (state) => ({ moves: state.moves + 1 }),
+    checkWin: (state) => state.moves >= 3,
+  };
+  const player = createDummyPlayer<State, Move>();
+  const tm = new TurnManager<State, Move, Phase>(
+    game,
+    [player, player],
+    'main',
+    (state, phase) => phase
+  );
+
+  tm.playTurn();
+  tm.playTurn();
+  const result = tm.playTurn();
+  assert.deepEqual(result, { winner: 0 });
+}
+
+testPhaseTransition();
+testWinDetection();
+console.log('All tests passed');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@lazyspa/core",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build && node dist/__tests__/turnManager.test.js"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/core/src/game.ts
+++ b/packages/core/src/game.ts
@@ -1,0 +1,16 @@
+export interface Game<State, Move> {
+  /**
+   * Create the initial game state.
+   */
+  init(): State;
+
+  /**
+   * Apply a move to the given state and return the new state.
+   */
+  applyMove(state: State, move: Move): State;
+
+  /**
+   * Determine whether the provided state represents a win.
+   */
+  checkWin(state: State): boolean;
+}

--- a/packages/core/src/player.ts
+++ b/packages/core/src/player.ts
@@ -1,0 +1,48 @@
+import { Game } from './game';
+
+export interface Player<State, Move, Phase extends string = string> {
+  readonly type: 'human' | 'ai';
+  getMove(state: State, phase: Phase): Move;
+}
+
+export class TurnManager<State, Move, Phase extends string = string> {
+  private currentPlayerIndex = 0;
+  private phase: Phase;
+  private state: State;
+
+  constructor(
+    private game: Game<State, Move>,
+    private players: [Player<State, Move, Phase>, Player<State, Move, Phase>],
+    initialPhase: Phase,
+    private phaseTransition: (state: State, phase: Phase) => Phase
+  ) {
+    this.state = game.init();
+    this.phase = initialPhase;
+  }
+
+  getPhase(): Phase {
+    return this.phase;
+  }
+
+  getState(): State {
+    return this.state;
+  }
+
+  getCurrentPlayer(): Player<State, Move, Phase> {
+    return this.players[this.currentPlayerIndex];
+  }
+
+  playTurn(): { winner: number | null } {
+    const player = this.getCurrentPlayer();
+    const move = player.getMove(this.state, this.phase);
+    this.state = this.game.applyMove(this.state, move);
+
+    if (this.game.checkWin(this.state)) {
+      return { winner: this.currentPlayerIndex };
+    }
+
+    this.phase = this.phaseTransition(this.state, this.phase);
+    this.currentPlayerIndex = 1 - this.currentPlayerIndex;
+    return { winner: null };
+  }
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "./",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "__tests__"]
+}


### PR DESCRIPTION
## Summary
- define generic `Game` interface with init, applyMove and checkWin
- add `Player` interface and `TurnManager` for alternating turns and phases
- document core package development workflow and declare TypeScript dependency

## Testing
- `cd packages/core && npm test` *(fails: tsc: not found)*
- `cd packages/core && npm install --save-dev typescript@5` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c10ffecc8324868a97ae8c2f35ce