### PR TITLE
fix(cpu): avoid self-removal when making mill

### DIFF
--- a/apps/src/daadi/cpu.test.ts
+++ b/apps/src/daadi/cpu.test.ts
@@ -1,0 +1,17 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { cpuBestRemoval } from './Gameplay';
+
+describe('cpu removal', () => {
+  it('chooses an opponent piece when removing after a mill', () => {
+    const board = Array(24).fill(0);
+    board[0]=board[1]=board[2]=-1; // CPU forms a mill
+    board[3]=1; board[5]=1; // opponent pieces
+    board[4]=-1; // extra CPU piece
+    const idx = cpuBestRemoval(board,'placing',{p1:1,p2:4},'nine',true);
+    assert.ok(idx !== null);
+    if(idx !== null){
+      assert.strictEqual(board[idx],1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- prevent CPU from accidentally removing its own piece after forming a mill
- evaluate and choose the best human piece to remove when CPU must capture
- add regression test to ensure CPU removes an opponent piece

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6cfe0428c832494e2eeeac4c62839